### PR TITLE
MOB-1087 (Removing a removed guid returns an error).

### DIFF
--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/account/RemoveAccount.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/account/RemoveAccount.java
@@ -77,17 +77,17 @@ public class RemoveAccount extends AbstractCommand {
     JSONObject json = commandPacket.getCommand();
     // The name of the account we are removing.
     String name = json.getString(GNSProtocol.NAME.toString());
-    // The guid of that wants to remove this account.
+    // The guid of the account we are removing.
     String guid = json.getString(GNSProtocol.GUID.toString());
     String signature = json.getString(GNSProtocol.SIGNATURE.toString());
     String message = json.getString(GNSProtocol.SIGNATUREFULLMESSAGE.toString());
     GuidInfo guidInfo;
-    // Fixme: verify that we might need to look remotely for this.
-    if ((guidInfo = AccountAccess.lookupGuidInfoAnywhere(header, guid, handler)) == null) {
-      return new CommandResponse(ResponseCode.BAD_GUID_ERROR, GNSProtocol.BAD_RESPONSE.toString() + " " + GNSProtocol.BAD_GUID.toString() + " " + guid);
+    if ((guidInfo = AccountAccess.lookupGuidInfoLocally(header, guid, handler)) == null) {
+      // Removing a non-existant guid is not longer an error.
+      return new CommandResponse(ResponseCode.NO_ERROR, GNSProtocol.OK_RESPONSE.toString());
+      //return new CommandResponse(ResponseCode.BAD_GUID_ERROR, GNSProtocol.BAD_RESPONSE.toString() + " " + GNSProtocol.BAD_GUID.toString() + " " + guid);
     }
     if (NSAccessSupport.verifySignature(guidInfo.getPublicKey(), signature, message)) {
-      // Fixme: verify that we might need to look remotely for this.
       AccountInfo accountInfo = AccountAccess.lookupAccountInfoFromNameAnywhere(header, name, handler);
       if (accountInfo != null) {
         return AccountAccess.removeAccount(header, commandPacket, accountInfo, handler);

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/account/RemoveGuid.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/account/RemoveGuid.java
@@ -79,8 +79,10 @@ public class RemoveGuid extends AbstractCommand {
     String message = json.getString(GNSProtocol.SIGNATUREFULLMESSAGE.toString());
     GuidInfo accountGuidInfo = null;
     GuidInfo guidInfoToRemove;
-    if ((guidInfoToRemove = AccountAccess.lookupGuidInfoAnywhere(header, guidToRemove, handler)) == null) {
-      return new CommandResponse(ResponseCode.BAD_GUID_ERROR, GNSProtocol.BAD_RESPONSE.toString() + " " + GNSProtocol.BAD_GUID.toString() + " " + guidToRemove);
+    if ((guidInfoToRemove = AccountAccess.lookupGuidInfoLocally(header, guidToRemove, handler)) == null) {
+      // Removing a non-existant guid is no longer an error.
+      return new CommandResponse(ResponseCode.NO_ERROR, GNSProtocol.OK_RESPONSE.toString());
+      //return new CommandResponse(ResponseCode.BAD_GUID_ERROR, GNSProtocol.BAD_RESPONSE.toString() + " " + GNSProtocol.BAD_GUID.toString() + " " + guidToRemove);
     }
     if (accountGuid != null) {
       if ((accountGuidInfo = AccountAccess.lookupGuidInfoAnywhere(header, accountGuid, handler)) == null) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/RemoveGuidTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/RemoveGuidTest.java
@@ -68,7 +68,7 @@ public class RemoveGuidTest {
    *
    */
   @Test
-  public void test_01_RemoveGuidUsingAccount() {
+  public void test_10_RemoveGuidUsingAccount() {
     String testGuidName = "testGUID" + RandomString.randomString(6);
     GuidEntry testGuid = null;
     try {
@@ -94,13 +94,14 @@ public class RemoveGuidTest {
     }
   }
 
+  private static String testGuidName = "testGUID" + RandomString.randomString(6);
+  private static GuidEntry testGuid = null;
+  
   /**
    *
    */
   @Test
-  public void test_02_RemoveGuid() {
-    String testGuidName = "testGUID" + RandomString.randomString(6);
-    GuidEntry testGuid = null;
+  public void test_20_RemoveGuid() {
     try {
       testGuid = client.guidCreate(masterGuid, testGuidName);
     } catch (Exception e) {
@@ -125,7 +126,19 @@ public class RemoveGuidTest {
    *
    */
   @Test
-  public void test_03_RemoveAccount() {
+  public void test_30_RemoveGuidAgain() {
+    try {
+      client.guidRemove(testGuid);
+    } catch (Exception e) {
+      fail("Exception while removing testGuid: " + e);
+    }
+  }
+
+  /**
+   *
+   */
+  @Test
+  public void test_40_RemoveAccount() {
     try {
       client.accountGuidRemove(masterGuid);
     } catch (Exception e) {
@@ -137,7 +150,7 @@ public class RemoveGuidTest {
    *
    */
   @Test
-  public void test_04_CheckForRemoval() {
+  public void test_50_CheckForRemoval() {
     try {
       client.lookupGuid(ACCOUNT_ALIAS);
       fail("lookupGuid for " + ACCOUNT_ALIAS + " should have throw an exception.");
@@ -145,6 +158,18 @@ public class RemoveGuidTest {
 
     } catch (IOException e) {
       fail("Exception while lookupAccountRecord for " + ACCOUNT_ALIAS + " :" + e);
+    }
+  }
+
+  /**
+   *
+   */
+  @Test
+  public void test_60_RemoveAccountAgain() {
+    try {
+      client.accountGuidRemove(masterGuid);
+    } catch (Exception e) {
+      fail("Exception while removing testGuid: " + e);
     }
   }
 }


### PR DESCRIPTION
Fixed RemoveGuid and RemoveAccount to return NO_ERROR when called on
non-existant guids. Also updated RemoveGuidTest to check for 
these cases.