### PR TITLE
Travis script for measuring failure rates

### DIFF
--- a/scripts/travis_template.sh
+++ b/scripts/travis_template.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+echo 0 > "successes"
+echo 0 > "failures"
+
+i=0
+while true; do
+	
+COMMAND_HERE
+err_status=$?
+
+successes=`cat successes`
+failures=`cat failures`
+if [[ $err_status == 0 ]]; then
+  successes=`expr $successes + 1`
+else 
+  failures=`expr $failures + 1`
+fi
+i=`expr $i + 1`
+echo $successes > "successes"
+echo $failures > "failures"
+echo "===Iteration $i, successes=$successes, failures=$failures==="
+done &
+
+echo "Background monitoring started at `date`.."
+# Travis gives 49 minutes exactly. ant takes ~1:30. 30 minutes buffer. So, 47 minutes = 2820 seconds.
+sleep 2820
+
+successes=`cat successes`
+failures=`cat failures`
+echo "=== Summary: successes=$successes, failures=$failures ==="
+if [ $successes -eq 0 ] && [ $failures -eq 0 ]; then
+	echo "No progress, something went wrong.."
+	exit 1
+elif [ $failures -gt 0 ]; then
+	echo "There are failures, exiting with 1.."
+	exit 1
+else
+	echo "All good, exiting with 0"
+	exit 0
+fi

--- a/scripts/travis_template.yml
+++ b/scripts/travis_template.yml
@@ -1,0 +1,14 @@
+language: java
+sudo: required
+jdk:
+- oraclejdk8
+services:
+- mongodb
+notifications:
+  email:
+    on_success: never
+    on_failure: never
+before_script:
+  ant
+script:
+  scripts/travis_checks.sh

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+
+# travis_test branch:commit handle [”ant testMethod…”|file] [rep_times]
+# travis_test branch:commit --status handle [--clean]
+
+set -e # Important, the whole script logic is dependent on this
+
+
+DEFAULT_COMMAND="ant test"
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+get_reponame () {
+	local user=$(basename $(dirname $1))
+	local repo=$(basename $1 .git)
+	echo $user"/"$repo
+}
+
+show_help () {
+	echo "
+	$0 branch:commit-SHA1
+	( handle ["command"] rep_times | --status handle [--clean])
+	
+	Ex: $0 master:abcde sample_test \"ant test\" 10
+	    $0 master:abcde --status sample_test --clean
+	"
+}
+
+check_branch_commit () {
+	git check-ref-format --branch $1 > /dev/null 
+	if ! [[ $2 =~ [a-f0-9]{5,40} ]]; then
+    	echo "Invalid commit SHA-1"
+    	show_help
+    	exit 1
+	fi
+}
+
+trigger_build(){
+	body='{
+"request": {
+  "branch":"'"$1"'"
+}}'
+
+repo=`echo "$account_repo"|sed 's;/;%2F;'`
+result=`curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token $2" \
+  -d "$body" \
+  "https://api.travis-ci.org/repo/$repo/requests"`
+}
+
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $scriptdir
+git_url=$(git ls-remote --get-url origin)
+account_repo=$(get_reponame $git_url)
+repo_root=$(git rev-parse --show-toplevel)
+
+if [ -z $1 ] || [[ ! $1 =~ : ]] ; then
+	echo "Invalid argument: $1"
+	show_help
+	exit 1
+fi
+
+if ! type "travis" > /dev/null; then
+  	echo "Travis CLI Client not found, enter token manually"
+  	read -p "Enter your Travis token" token
+else
+	token=`travis token|cut -f 5`
+	echo "Your Travis token is $token"
+fi
+
+branch_n_commit=(${1//:/ })
+target_branch=${branch_n_commit[0]}
+target_commit=${branch_n_commit[1]}
+
+check_branch_commit $target_branch $target_commit
+
+echo "Repository    : ${bold}$account_repo ${normal}"
+echo "Project root  : ${bold}$repo_root ${normal}"
+echo "Target branch : ${bold}$target_branch${normal}"
+echo "Target commit : ${bold}$target_commit${normal}"
+short_commit=$(echo $target_commit|cut -c1-5)
+
+if [[ $2 =~ ^--status$ ]] ; then
+	
+	if [ -z $3 ]; then
+		echo "Error: Handle expected"
+		show_help
+		exit 1
+	fi
+
+	new_branch="travis_temp_""$short_commit""_""$3"
+	echo "Fetching runs from $new_branch.."
+	dirn="$repo_root""/logs_""$short_commit""_""$3"
+	hist=`travis history -r $account_repo -b $new_branch -l 10000`
+	output=`echo "$hist"|cut -f 1 -d ' '|cut -f 2 -d '#'`
+	totalcount=`echo "$output"| sed '/^\s*$/d' | wc -l`
+	echo "${bold}$totalcount${normal} test run(s) found"
+
+	passcount=`echo "$hist"|grep passed|wc -l`
+	if [ $passcount -ne 0 ]; then
+		echo "${bold}$passcount${normal} successful"
+	fi
+
+	failcount=`echo "$hist"|grep failed|wc -l`
+	if [ $failcount -ne 0 ]; then
+		echo "${bold}$failcount${normal} failure(s)"
+	fi
+
+	errcount=`echo "$hist"|grep errored|wc -l`
+	if [ $errcount -ne 0 ]; then
+		echo "${bold}$errcount${normal} error/timeout(s)"
+	fi
+	
+
+	startedcount=`echo "$hist"|grep started|wc -l`
+	if [ $startedcount -ne 0 ]; then
+		echo "${bold}$startedcount${normal} running"
+	fi
+	
+
+	yetcount=`echo "$hist"|grep created|wc -l`
+	if [ $yetcount -ne 0 ]; then
+		echo "${bold}$yetcount${normal} yet to start"
+	fi
+	
+	echo "Downloading errored/failed logs.."
+	sleep 2
+	output=`echo "$hist"|grep -iE "errored|failed"|cut -f 1 -d ' '|cut -f 2 -d '#'`
+	totalcount=`echo "$output"|wc -l`
+	currentcount="0"
+	set +e
+	while read testid
+	do
+		if [[  $testid =~ ^[0-9]+$ ]]; then
+		  mkdir -p "$dirn"
+		  nextcount=$(($currentcount+1))
+		  perc=`echo $(( $nextcount * 100 / $totalcount ))`
+		  echo -ne "  Downloading logs $nextcount of $totalcount ($perc%)\033[0K\r"
+		  travis logs $testid -r $account_repo --no-interactive &> $dirn"/"$testid"_travis_"$3".log"
+		  currentcount=$(($currentcount+1))
+		fi
+	done <<< "$(echo -e "$output")"
+
+	if [ "$currentcount" -gt 0 ]; then
+		echo -e "\nLogs downloaded to ${bold}$dirn${normal}"
+	else
+		echo -e "\nNo logs to download"
+	fi
+
+	if [[ $4 =~ ^--clean$ ]] ; then
+		echo "Deleting local and remote branch $new_branch"
+		set +e
+		git branch -D $new_branch
+		git push origin --delete $new_branch
+		set -e
+	fi
+
+else
+	handle=$2
+	command=$3
+	n=$4
+
+	if [[ $command =~ ^[0-9]+$ ]] ; then
+		n=$command
+		command=$DEFAULT_COMMAND
+	fi
+	
+	if ! [[ $n =~ ^[0-9]+$ ]] ; then
+		echo "Error: Invaid rep_times"
+		show_help
+		exit 1
+	fi
+
+	current_branch=$(git rev-parse --abbrev-ref HEAD)
+	new_branch="travis_temp_""$short_commit""_""$handle"
+	git check-ref-format --branch $new_branch > /dev/null
+	travis_template=`cat $scriptdir/travis_template.sh`
+	sh_content=`echo "$travis_template"|sed 's~COMMAND_HERE~'"$command"'~'`
+	yml_content=`cat "$scriptdir/travis_template.yml"`
+	
+	git checkout $target_branch
+	git pull origin $target_branch
+	echo "Checking out new branch $new_branch"
+	git checkout -b $new_branch $target_commit
+
+	echo "$sh_content" > "$scriptdir/travis_checks.sh"
+	echo "$yml_content" > "$repo_root/.travis.yml"
+	echo "Successfully wrote Travis script"
+	git add -A
+	git commit -am "Temp commit from Travis script"
+	git push origin $new_branch
+	git checkout $current_branch
+
+	times="1"
+	while [[ $times -le $n ]]; do
+		echo -ne "  Attempting to trigger build $times of $n \033[0K\r"
+		trigger_build $new_branch $token
+		if [[ ${result} == *"remaining"* ]];then
+			sleep 2
+	    	echo -ne "  Successful \033[0K\r"
+	    	sleep 2
+	    	echo "  Trigger $times completed"
+	    	times=$((times+1))
+	    elif [[ ${result} == *"request_limit_reached"* ]]; then
+			echo -ne "  Hourly trigger limit exceeded, will retry in a while .. \033[0K\r"
+			sleep 500
+		else
+			echo "An error occured, unable to parse response"
+			echo "$result"
+			exit 1
+		fi
+	done
+fi
+
+
+

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -178,6 +178,7 @@ else
 	new_branch="travis_temp_""$short_commit""_""$handle"
 	git check-ref-format --branch $new_branch > /dev/null
 	travis_template=`cat $scriptdir/travis_template.sh`
+	command=`echo ${command}|tr '\n' "\\n"`
 	sh_content=`echo "$travis_template"|sed 's~COMMAND_HERE~'"$command"'~'`
 	yml_content=`cat "$scriptdir/travis_template.yml"`
 	

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -190,6 +190,7 @@ else
 	echo "$sh_content" > "$scriptdir/travis_checks.sh"
 	echo "$yml_content" > "$repo_root/.travis.yml"
 	echo "Successfully wrote Travis script"
+	exit
 	git add -A
 	git commit -am "Temp commit from Travis script"
 	git push origin $new_branch

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -178,7 +178,7 @@ else
 	new_branch="travis_temp_""$short_commit""_""$handle"
 	git check-ref-format --branch $new_branch > /dev/null
 	travis_template=`cat $scriptdir/travis_template.sh`
-	command=`echo ${command}|tr '\n' "\\n"`
+	command=`echo ${command}|tr '\n' "\\\n"`
 	sh_content=`echo "$travis_template"|sed 's~COMMAND_HERE~'"$command"'~'`
 	yml_content=`cat "$scriptdir/travis_template.yml"`
 	

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -178,8 +178,9 @@ else
 	new_branch="travis_temp_""$short_commit""_""$handle"
 	git check-ref-format --branch $new_branch > /dev/null
 	travis_template=`cat $scriptdir/travis_template.sh`
-	command=`echo ${command}|tr '\n' "\\\n"`
-	sh_content=`echo "$travis_template"|sed 's~COMMAND_HERE~'"$command"'~'`
+	command_escaped=$(printf '%s\n' "$command" | sed 's,[\/&],\\&,g;s/$/\\/')
+	command_escaped=${command_escaped%?}
+	sh_content=`echo "$travis_template"|sed 's~COMMAND_HERE~'"$command_escaped"'~'`
 	yml_content=`cat "$scriptdir/travis_template.yml"`
 	
 	git checkout $target_branch
@@ -190,7 +191,6 @@ else
 	echo "$sh_content" > "$scriptdir/travis_checks.sh"
 	echo "$yml_content" > "$repo_root/.travis.yml"
 	echo "Successfully wrote Travis script"
-	exit
 	git add -A
 	git commit -am "Temp commit from Travis script"
 	git push origin $new_branch

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# travis_test branch:commit handle [”ant testMethod…”|file] [rep_times]
+# travis_test branch:commit handle ”command” [rep_times]
 # travis_test branch:commit --status handle [--clean]
 
 set -e # Important, the whole script logic is dependent on this
@@ -22,6 +22,7 @@ show_help () {
 	( handle ["command"] rep_times | --status handle [--clean])
 	
 	Ex: $0 master:abcde sample_test \"ant test\" 10
+	    $0 master:abcde sample_test \"\`cat path/to/file.sh\`\" 10
 	    $0 master:abcde --status sample_test --clean
 	"
 }


### PR DESCRIPTION
This change introduces a script that can be used to trigger multiple test runs on Travis CI. The same script can also be later used to identify if there were any failures. Typical use cases include measuring the failure rate of GNS at a particular commit in a particular branch. 

Usage:

```
	./scripts/travis_test.sh branch:commit-SHA1
	( handle [command] rep_times | --status handle [--clean])

	Ex: ./scripts/travis_test.sh master:abcde sample_test "ant test" 10
	    ./scripts/travis_test.sh master:abcde sample_test "`cat file.sh`" 10
	    ./scripts/travis_test.sh master:abcde --status sample_test --clean
```
`handle` is a unique identifier used to identify a particular instantiation of the script.
`rep_times` is the number of Travis instances to be started. Each instance runs the `command` for about 50 minutes repeatedly.

This script requires [Travis CLI](https://github.com/travis-ci/travis.rb) to be installed. It can also be used on a server like `date.cs.umass.edu` without installing Travis CLI (by manually providing Travis token when asked). Instead of providing a single-line command,    `` "`cat file.sh`" `` can be used to execute the contents of `file.sh` on Travis.