### PR TITLE
Removed errant use of "GNSClient client" from ServerIntegration test.

### DIFF
--- a/src/edu/umass/cs/gnsserver/main/GNSConfig.java
+++ b/src/edu/umass/cs/gnsserver/main/GNSConfig.java
@@ -312,10 +312,10 @@ public class GNSConfig {
      */
     DISABLE_MULTI_SERVER_HTTP(false),
     /**
-     * Turn off active code handling. Default is false.
+     * Turn off active code handling. Default is true.
      * Temporary - The use of this will go away at some point.
      */
-    DISABLE_ACTIVE_CODE(false);
+    DISABLE_ACTIVE_CODE(true);
 
     final Object defaultValue;
     final boolean unsafeTestingOnly;

--- a/test/edu/umass/cs/gnsclient/client/integrationtests/ServerIntegrationTest.java
+++ b/test/edu/umass/cs/gnsclient/client/integrationtests/ServerIntegrationTest.java
@@ -92,8 +92,6 @@ public class ServerIntegrationTest extends DefaultGNSTest {
   // ALIAS
   private static final String PASSWORD = "password";
   private static GNSClientCommands clientCommands = null;
-  private static GNSClient client = null;
-  //private static GNSClientCommandsV2 client = null;
   private static GuidEntry masterGuid;
   
   private static final int REPEAT = 10;


### PR DESCRIPTION
It must have sneaked in during the last merge. Also disabled active code
due to the issue seen in MOB-1095.