### PR TITLE
Restore basic DNS with forwarder functionality

### DIFF
--- a/conf/dns/gnsserver.1dns.local.properties
+++ b/conf/dns/gnsserver.1dns.local.properties
@@ -1,0 +1,25 @@
+# The list of property names and values that can be specified here
+# may be found in the enum PaxosConfig.PC, ReconfigurationConfig.RC,
+# GNSConfig.GNSC (for GNS servers), and GNSClientConfig.GNSCC (for GNS
+# clients). 
+
+#ENABLE_DISKMAP=true
+#IN_MEMORY_DB=true
+
+# NOTE: CURRENTLY NECESSARY TO DISABLE EMAIL VERFICATION FOR UNIT TESTING SO
+# WE CAN CREATE ACCOUNTS WITHOUT EMAIL VERIFYING THEM
+ENABLE_EMAIL_VERIFICATION=false
+
+CLIENT_SSL_MODE=SERVER_AUTH
+SERVER_SSL_MODE=MUTUAL_AUTH
+DEMAND_PROFILE_TYPE=edu.umass.cs.gnsserver.gnsapp.NullDemandProfile
+
+# use with ReconfigurableNode <nodeID>*
+APPLICATION=edu.umass.cs.gnsserver.gnsapp.GNSApp
+
+active.GNSApp1=127.0.0.1:24403
+
+reconfigurator.reconfigurator1=127.0.0.1:2178
+
+#Specify which nodes should run the DNS service 
+DNS_SERVER_NODES=all

--- a/src/edu/umass/cs/gnsserver/gnamed/UdpDnsServer.java
+++ b/src/edu/umass/cs/gnsserver/gnamed/UdpDnsServer.java
@@ -77,8 +77,7 @@ public class UdpDnsServer extends Thread implements Shutdownable {
    */
   public UdpDnsServer(InetAddress addr, int port, String dnsServerIP, String gnsServerIP,
           ClientRequestHandlerInterface handler) throws SecurityException, SocketException, UnknownHostException {
-	// set it to null to make it non-recursive
-    this.dnsServer = null; //dnsServerIP != null ? new SimpleResolver(dnsServerIP) : null;
+    this.dnsServer = dnsServerIP != null ? new SimpleResolver(dnsServerIP) : null;
     this.gnsServer = gnsServerIP != null ? new SimpleResolver(gnsServerIP) : null;
     this.dnsCache = dnsServerIP != null ? new Cache() : null;
     this.dnsServerIP = dnsServerIP;


### PR DESCRIPTION
* Revert change in UdpDnsServer that caused the DNS service to only perform local lookups. This was likely a result of someone trying to perform strictly local lookups but not knowing about the DNS_GNS_ONLY config option.

* Add DNS config file for a local DNS server.

To test:
1.  `bin/gpServer.sh -DgigapaxosConfig=conf/dns/gnsserver.1dns.local.properties restart all`
2.  Perform DNS query against server with `nslookup` or a similar tool

Since this is a small commit I recommend rebasing and merging to help keep the git history clean, but that's more of a personal practice.