### PR TITLE
Remove dependency on javax.xml.DatatypeConverter

### DIFF
--- a/src/edu/umass/cs/gnsclient/client/CommandUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/CommandUtils.java
@@ -29,6 +29,7 @@ import edu.umass.cs.gnscommon.exceptions.client.InvalidGuidException;
 import edu.umass.cs.gnscommon.exceptions.client.VerificationException;
 import edu.umass.cs.gnscommon.packets.CommandPacket;
 import edu.umass.cs.gnscommon.packets.ResponsePacket;
+import edu.umass.cs.gnscommon.utils.ByteUtils;
 import edu.umass.cs.gnscommon.utils.CanonicalJSON;
 import edu.umass.cs.gnscommon.utils.Format;
 import edu.umass.cs.gnscommon.exceptions.client.OperationNotSupportedException;
@@ -59,7 +60,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import edu.umass.cs.gnscommon.GNSProtocol;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  *
@@ -185,8 +185,8 @@ public class CommandUtils {
       // but the iOS client does as well so we need to keep it like this.
       // Also note that the secret based method doesn't do this - it just returns a string
       // using the ISO-8859-1 charset.
-      String result = DatatypeConverter.printHexBinary(signedString);
-      //String result = ByteUtils.toHex(signedString);
+      //String result = DatatypeConverter.printHexBinary(signedString);
+      String result = ByteUtils.toHex(signedString);
       return result;
     }
   }

--- a/src/edu/umass/cs/gnsclient/client/util/KeyPairUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/util/KeyPairUtils.java
@@ -44,8 +44,8 @@ import edu.umass.cs.gnsclient.client.util.keystorage.AbstractKeyStorage;
 import edu.umass.cs.gnsclient.client.util.keystorage.JavaPreferencesKeyStore;
 import edu.umass.cs.gnsclient.client.util.keystorage.SimpleKeyStore;
 import edu.umass.cs.gnscommon.GNSProtocol;
+import edu.umass.cs.gnscommon.utils.ByteUtils;
 import edu.umass.cs.utils.Config;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * @author westy
@@ -93,10 +93,10 @@ public class KeyPairUtils {
     String privateString = keyStorageObj.get(generateKey(gnsName, username, PRIVATE), "");
     if (!guid.isEmpty() && !publicString.isEmpty() && !privateString.isEmpty()) {
       try {
-        byte[] encodedPublicKey = DatatypeConverter.parseHexBinary(publicString);
-        //byte[] encodedPublicKey = ByteUtils.hexStringToByteArray(publicString);
-        byte[] encodedPrivateKey = DatatypeConverter.parseHexBinary(privateString);
-        //byte[] encodedPrivateKey = ByteUtils.hexStringToByteArray(privateString);
+        //byte[] encodedPublicKey = DatatypeConverter.parseHexBinary(publicString);
+        byte[] encodedPublicKey = ByteUtils.hexStringToByteArray(publicString);
+        //byte[] encodedPrivateKey = DatatypeConverter.parseHexBinary(privateString);
+        byte[] encodedPrivateKey = ByteUtils.hexStringToByteArray(privateString);
         KeyFactory keyFactory = KeyFactory.getInstance(GNSProtocol.RSA_ALGORITHM.toString());
         X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encodedPublicKey);
         PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
@@ -147,10 +147,10 @@ public class KeyPairUtils {
 
     createSingleton();
 
-    String publicString =  DatatypeConverter.printHexBinary(keyPair.getPublic().getEncoded());
-    String privateString =  DatatypeConverter.printHexBinary(keyPair.getPrivate().getEncoded());
-    //String publicString = ByteUtils.toHex(keyPair.getPublic().getEncoded());
-    //String privateString = ByteUtils.toHex(keyPair.getPrivate().getEncoded());
+    //String publicString =  DatatypeConverter.printHexBinary(keyPair.getPublic().getEncoded());
+    //String privateString =  DatatypeConverter.printHexBinary(keyPair.getPrivate().getEncoded());
+    String publicString = ByteUtils.toHex(keyPair.getPublic().getEncoded());
+    String privateString = ByteUtils.toHex(keyPair.getPrivate().getEncoded());
     keyStorageObj.put(generateKey(gnsName, username, PUBLIC), publicString);
     keyStorageObj.put(generateKey(gnsName, username, PRIVATE), privateString);
     keyStorageObj.put(generateKey(gnsName, username, GUID), guid);

--- a/src/edu/umass/cs/gnsclient/client/util/KeyPairUtilsAndroid.java
+++ b/src/edu/umass/cs/gnsclient/client/util/KeyPairUtilsAndroid.java
@@ -40,7 +40,7 @@ import android.os.Environment;
 import android.util.Log;
 import edu.umass.cs.gnscommon.exceptions.client.EncryptionException;
 import edu.umass.cs.gnscommon.GNSProtocol;
-import javax.xml.bind.DatatypeConverter;
+import edu.umass.cs.gnscommon.utils.ByteUtils;
 
 /**
  * Class to store and retrieve key value pairs in Android.
@@ -129,10 +129,10 @@ public class KeyPairUtilsAndroid {
    */
   public static void saveKeyPairToPreferences(String gnsName, String username, String guid, KeyPair keyPair) {
     String aliasKey = gnsName + "@" + username;
-    String publicString =  DatatypeConverter.printHexBinary(keyPair.getPublic().getEncoded());
-    String privateString =  DatatypeConverter.printHexBinary(keyPair.getPrivate().getEncoded());
-    //String publicString = ByteUtils.toHex(keyPair.getPublic().getEncoded());
-    //String privateString = ByteUtils.toHex(keyPair.getPrivate().getEncoded());
+    //String publicString =  DatatypeConverter.printHexBinary(keyPair.getPublic().getEncoded());
+    //String privateString =  DatatypeConverter.printHexBinary(keyPair.getPrivate().getEncoded());
+    String publicString = ByteUtils.toHex(keyPair.getPublic().getEncoded());
+    String privateString = ByteUtils.toHex(keyPair.getPrivate().getEncoded());
 
     if (readGuidEntryFromFile(gnsName, username) != null) // entry already there just return
     {
@@ -361,10 +361,10 @@ public class KeyPairUtilsAndroid {
 
         if (aliasKey.contains(gnsName) && !publicString.isEmpty() && !privateString.isEmpty()) {
           try {
-            byte[] encodedPublicKey = DatatypeConverter.parseHexBinary(publicString);
-            byte[] encodedPrivateKey = DatatypeConverter.parseHexBinary(privateString);
-            //byte[] encodedPublicKey = ByteUtils.hexStringToByteArray(publicString);
-            //byte[] encodedPrivateKey = ByteUtils.hexStringToByteArray(privateString);
+            //byte[] encodedPublicKey = DatatypeConverter.parseHexBinary(publicString);
+            //byte[] encodedPrivateKey = DatatypeConverter.parseHexBinary(privateString);
+            byte[] encodedPublicKey = ByteUtils.hexStringToByteArray(publicString);
+            byte[] encodedPrivateKey = ByteUtils.hexStringToByteArray(privateString);
             KeyFactory keyFactory = KeyFactory.getInstance(GNSProtocol.RSA_ALGORITHM.toString());
             X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encodedPublicKey);
             PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
@@ -445,10 +445,10 @@ public class KeyPairUtilsAndroid {
 
           if (!publicString.isEmpty() && !privateString.isEmpty()) {
             try {
-              byte[] encodedPublicKey = DatatypeConverter.parseHexBinary(publicString);
-              byte[] encodedPrivateKey = DatatypeConverter.parseHexBinary(privateString);
-//              byte[] encodedPublicKey = ByteUtils.hexStringToByteArray(publicString);
-//              byte[] encodedPrivateKey = ByteUtils.hexStringToByteArray(privateString);
+              //byte[] encodedPublicKey = DatatypeConverter.parseHexBinary(publicString);
+              //byte[] encodedPrivateKey = DatatypeConverter.parseHexBinary(privateString);
+                byte[] encodedPublicKey = ByteUtils.hexStringToByteArray(publicString);
+                byte[] encodedPrivateKey = ByteUtils.hexStringToByteArray(privateString);
               KeyFactory keyFactory = KeyFactory.getInstance(GNSProtocol.RSA_ALGORITHM.toString());
               X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encodedPublicKey);
               PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);

--- a/src/edu/umass/cs/gnscommon/SharedGuidUtils.java
+++ b/src/edu/umass/cs/gnscommon/SharedGuidUtils.java
@@ -20,10 +20,10 @@
 package edu.umass.cs.gnscommon;
 
 import edu.umass.cs.gnscommon.utils.Base64;
+import edu.umass.cs.gnscommon.utils.ByteUtils;
 import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commandSupport.ShaOneHashFunction;
 import java.util.HashSet;
 import java.util.Set;
-import javax.xml.bind.DatatypeConverter;
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -43,8 +43,8 @@ public class SharedGuidUtils {
    */
   public static String createGuidStringFromPublicKey(byte[] keyBytes) {
     byte[] publicKeyDigest = ShaOneHashFunction.getInstance().hash(keyBytes);
-    return DatatypeConverter.printHexBinary(publicKeyDigest);
-    //return ByteUtils.toHex(publicKeyDigest);
+    //return DatatypeConverter.printHexBinary(publicKeyDigest);
+    return ByteUtils.toHex(publicKeyDigest);
   }
 
   /**

--- a/src/edu/umass/cs/gnscommon/utils/ByteUtils.java
+++ b/src/edu/umass/cs/gnscommon/utils/ByteUtils.java
@@ -154,44 +154,44 @@ public class ByteUtils {
     return value;
   }
 
-//  /**
-//   * Converts a hexidecimal string to a byte array.
-//   * 
-//   * @param s
-//   * @return a byte array
-//   */
-//  public static byte[] hexStringToByteArray(String s) {
-//    int len = s.length();
-//    byte[] data = new byte[len / 2];
-//    for (int i = 0; i < len; i += 2) {
-//      data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
-//    }
-//    return data;
-//  }
+  /**
+   * Converts a hexidecimal string to a byte array.
+   *
+   * @param s
+   * @return a byte array
+   */
+  public static byte[] hexStringToByteArray(String s) {
+    int len = s.length();
+    byte[] data = new byte[len / 2];
+    for (int i = 0; i < len; i += 2) {
+      data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
+    }
+    return data;
+  }
 
-//  /**
-//   * Converts a byte array to a hex string.
-//   * 
-//   * @param bytes
-//   * @return the string
-//   */
-//  public static String toHex(byte[] bytes) {
-//    StringBuilder sb = new StringBuilder();
-//    for (int i = 0; i < bytes.length; i++) {
-//      sb.append(toHex(bytes[i]));
-//    }
-//    return sb.toString();
-//  }
+  /**
+   * Converts a byte array to a hex string.
+   *
+   * @param bytes
+   * @return the string
+   */
+  public static String toHex(byte[] bytes) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < bytes.length; i++) {
+      sb.append(toHex(bytes[i]));
+    }
+    return sb.toString();
+  }
 //
-//  /**
-//   * Converts a byte to a two digit hex string.
-//   * 
-//   * @param b
-//   * @return the string
-//   */
-//  public static String toHex(byte b) {
-//    return String.format("%02X", b);
-//  }
+  /**
+   * Converts a byte to a two digit hex string.
+   *
+   * @param b
+   * @return the string
+   */
+  public static String toHex(byte b) {
+    return String.format("%02X", b);
+  }
   
   
   


### PR DESCRIPTION
This change is to make j2objc work with GNSClient, as j2objc doesn't support `javax.xml.*` yet