### PR TITLE
Move crypto stuff to CryptoUtils

### DIFF
--- a/src/edu/umass/cs/gnsclient/client/CommandUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/CommandUtils.java
@@ -51,7 +51,7 @@ import edu.umass.cs.gnscommon.GNSProtocol;
 public class CommandUtils {
 
 
-  static Random random;
+  private static Random random;
   static {
     random = new Random();
   }

--- a/src/edu/umass/cs/gnsclient/client/CommandUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/CommandUtils.java
@@ -37,6 +37,8 @@ import edu.umass.cs.utils.Config;
 import edu.umass.cs.utils.DelayProfiler;
 
 import java.util.Date;
+import java.util.Random;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -49,6 +51,16 @@ import edu.umass.cs.gnscommon.GNSProtocol;
 public class CommandUtils {
 
 
+  static Random random;
+  static {
+    random = new Random();
+  }
+  /**
+   * @return Random long.
+   */
+  public static String getRandomRequestNonce() {
+    return (random.nextLong() + "");
+  }
 
   /**
    * Creates a command object from the given action string and a variable
@@ -326,7 +338,7 @@ public class CommandUtils {
       result.put(GNSProtocol.TIMESTAMP.toString(),
               Format.formatDateISO8601UTC(new Date()));
     }
-    result.put(GNSProtocol.NONCE.toString(), CryptoUtils.getRandomRequestNonce());
+    result.put(GNSProtocol.NONCE.toString(), getRandomRequestNonce());
     return result;
   }
   

--- a/src/edu/umass/cs/gnsclient/client/CommandUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/CommandUtils.java
@@ -32,34 +32,15 @@ import edu.umass.cs.gnscommon.packets.ResponsePacket;
 import edu.umass.cs.gnscommon.utils.CanonicalJSON;
 import edu.umass.cs.gnscommon.utils.Format;
 import edu.umass.cs.gnscommon.exceptions.client.OperationNotSupportedException;
-import edu.umass.cs.gnsserver.main.GNSConfig;
 import edu.umass.cs.nio.JSONPacket;
 import edu.umass.cs.utils.Config;
 import edu.umass.cs.utils.DelayProfiler;
-import edu.umass.cs.utils.SessionKeys;
-import edu.umass.cs.utils.SessionKeys.SecretKeyCertificate;
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
-import java.security.InvalidKeyException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.Signature;
-import java.security.SignatureException;
+
 import java.util.Date;
-import java.util.Random;
-import java.util.logging.Level;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import edu.umass.cs.gnscommon.GNSProtocol;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  *
@@ -67,29 +48,7 @@ import javax.xml.bind.DatatypeConverter;
  */
 public class CommandUtils {
 
-  /* arun: at least as many instances as cores for parallelism. */
-  private static Signature[] signatureInstances = new Signature[2 * Runtime
-          .getRuntime().availableProcessors()];
-  private static Random random;
 
-  static {
-    try {
-      for (int i = 0; i < signatureInstances.length; i++) {
-        signatureInstances[i] = Signature
-                .getInstance(GNSProtocol.SIGNATURE_ALGORITHM.toString());
-      }
-      random = new Random();
-    } catch (NoSuchAlgorithmException e) {
-      GNSConfig.getLogger().log(Level.SEVERE,
-              "Unable to initialize for authentication:{0}", e);
-    }
-  }
-
-  private static int sigIndex = 0;
-
-  private static synchronized Signature getSignatureInstance() {
-    return signatureInstances[sigIndex++ % signatureInstances.length];
-  }
 
   /**
    * Creates a command object from the given action string and a variable
@@ -155,138 +114,7 @@ public class CommandUtils {
     }
   }
 
-  /**
-   * Signs a digest of a message using private key of the given guid.
-   *
-   * @param privateKey
-   * @param message
-   * @return a signed digest of the message string encoded as a hex string
-   * @throws InvalidKeyException
-   * @throws NoSuchAlgorithmException
-   * @throws SignatureException
-   * @throws java.io.UnsupportedEncodingException
-   *
-   * arun: This method need to be synchronized over the signature
-   * instance, otherwise it will result in corrupted signatures.
-   */
-  public static String signDigestOfMessage(PrivateKey privateKey,
-          String message) throws NoSuchAlgorithmException,
-          InvalidKeyException, SignatureException,
-          UnsupportedEncodingException {
-    Signature signatureInstance = getSignatureInstance();
-    synchronized (signatureInstance) {
-      signatureInstance.initSign(privateKey);
-      // iOS client uses UTF-8 - should switch to ISO-8859-1 to be consistent with
-      // secret key version
-      signatureInstance.update(message.getBytes("UTF-8"));
-      byte[] signedString = signatureInstance.sign();
-      // We used to encode this as a hex so we could send it with the html without
-      // encoding. Not really necessary anymore for the socket based client,
-      // but the iOS client does as well so we need to keep it like this.
-      // Also note that the secret based method doesn't do this - it just returns a string
-      // using the ISO-8859-1 charset.
-      String result = DatatypeConverter.printHexBinary(signedString);
-      //String result = ByteUtils.toHex(signedString);
-      return result;
-    }
-  }
 
-  private static final MessageDigest[] mds = new MessageDigest[Runtime
-          .getRuntime().availableProcessors()];
-
-  static {
-    for (int i = 0; i < mds.length; i++) {
-      try {
-        mds[i] = MessageDigest
-                .getInstance(GNSProtocol.DIGEST_ALGORITHM.toString());
-      } catch (NoSuchAlgorithmException e) {
-        e.printStackTrace();
-        System.exit(1);
-      }
-    }
-  }
-  private static int mdIndex = 0;
-
-  private static MessageDigest getMessageDigestInstance() {
-    return mds[mdIndex++ % mds.length];
-  }
-
-  private static final Cipher[] ciphers = new Cipher[2 * Runtime.getRuntime()
-          .availableProcessors()];
-
-  static {
-    for (int i = 0; i < ciphers.length; i++) {
-      try {
-        ciphers[i] = Cipher
-                .getInstance(GNSProtocol.SECRET_KEY_ALGORITHM.toString());
-      } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-        e.printStackTrace();
-        System.exit(1);
-      }
-    }
-  }
-
-  private static int cipherIndex = 0;
-
-  private static Cipher getCipherInstance() {
-    return ciphers[cipherIndex++ % ciphers.length];
-  }
-
-  /**
-   * @param privateKey
-   * @param publicKey
-   * @param message
-   * @return Signature encoded as a hex string
-   * @throws NoSuchAlgorithmException
-   * @throws InvalidKeyException
-   * @throws SignatureException
-   * @throws UnsupportedEncodingException
-   * @throws IllegalBlockSizeException
-   * @throws BadPaddingException
-   * @throws NoSuchPaddingException
-   */
-  public static String signDigestOfMessage(PrivateKey privateKey,
-          PublicKey publicKey, String message)
-          throws NoSuchAlgorithmException, InvalidKeyException,
-          SignatureException, UnsupportedEncodingException,
-          IllegalBlockSizeException, BadPaddingException,
-          NoSuchPaddingException {
-    SecretKey secretKey = SessionKeys.getOrGenerateSecretKey(publicKey,
-            privateKey);
-    MessageDigest md = getMessageDigestInstance();
-    byte[] digest;
-    // FIXME: The reason why we use CHARSET should be more throughly documented here.
-    // This might be important for folks writing clients in other languages.
-    byte[] body = message.getBytes(GNSProtocol.CHARSET.toString());
-    synchronized (md) {
-      digest = md.digest(body);
-    }
-    assert (digest != null);
-    Cipher cipher = getCipherInstance();
-    byte[] signature;
-    synchronized (cipher) {
-      cipher.init(Cipher.ENCRYPT_MODE, secretKey);
-      signature = cipher.doFinal(digest);
-    }
-
-    SecretKeyCertificate skCert = SessionKeys
-            .getSecretKeyCertificate(publicKey);
-    byte[] encodedSKCert = skCert.getEncoded(false);
-
-    // arun: Combining them like this because the rest of the GNS code seems
-    // poorly organized to add more signature related fields in a systematic
-    // manner.
-    byte[] combined = new byte[Short.BYTES + signature.length + Short.BYTES
-            + encodedSKCert.length];
-    ByteBuffer.wrap(combined)
-            // signature
-            .putShort((short) signature.length).put(signature)
-            // certificate
-            .putShort((short) encodedSKCert.length).put(encodedSKCert);
-
-    // FIXME: The reason why we use CHARSET should be more throughly documented here.
-    return new String(combined, GNSProtocol.CHARSET.toString());
-  }
 
   /**
    * This little dance is because we need to remove the signature to get the
@@ -480,13 +308,6 @@ public class CommandUtils {
   }
 
   /**
-   * @return Random long.
-   */
-  public static String getRandomRequestNonce() {
-    return (random.nextLong() + "");
-  }
-
-  /**
    * Creates a JSON Object from the given command, keypair and a variable
    * number of key and value pairs. Includes a NONCE and TIMESTAMP field.
    * 
@@ -505,7 +326,7 @@ public class CommandUtils {
       result.put(GNSProtocol.TIMESTAMP.toString(),
               Format.formatDateISO8601UTC(new Date()));
     }
-    result.put(GNSProtocol.NONCE.toString(), getRandomRequestNonce());
+    result.put(GNSProtocol.NONCE.toString(), CryptoUtils.getRandomRequestNonce());
     return result;
   }
   
@@ -520,8 +341,8 @@ public class CommandUtils {
    * @return Signed command.
    * @throws ClientException
    */
-  public static JSONObject createAndSignCommand(CommandType commandType,
-          PrivateKey privateKey, PublicKey publicKey, Object... keysAndValues)
+  public static JSONObject createAndSignCommandInternal(CommandType commandType,
+          GuidEntry guidEntry, Object... keysAndValues)
           throws ClientException {
     try {
       JSONObject result = createCommandWithTimestampAndNonce(commandType, true, keysAndValues);
@@ -529,16 +350,16 @@ public class CommandUtils {
       String signatureString = null;
       long t = System.nanoTime();
       if (Config.getGlobalBoolean(GNSCC.ENABLE_SECRET_KEY)) {
-        signatureString = signDigestOfMessage(privateKey, publicKey, canonicalJSON);
+        signatureString = CryptoUtils.signDigestOfMessageSecretKey(guidEntry, canonicalJSON);
       } else {
-        signatureString = signDigestOfMessage(privateKey, canonicalJSON);
+        signatureString = CryptoUtils.signDigestOfMessage(guidEntry, canonicalJSON);
       }
       result.put(GNSProtocol.SIGNATURE.toString(), signatureString);
       if (edu.umass.cs.utils.Util.oneIn(10)) {
         DelayProfiler.updateDelayNano("signature", t);
       }
       return result;
-    } catch (JSONException | NoSuchAlgorithmException | InvalidKeyException | SignatureException | UnsupportedEncodingException | IllegalBlockSizeException | BadPaddingException | NoSuchPaddingException e) {
+    } catch (JSONException e) {
       throw new ClientException("Error encoding message", e);
     }
   }
@@ -553,8 +374,8 @@ public class CommandUtils {
   public static JSONObject createAndSignCommand(CommandType commandType,
           GuidEntry querier, Object... keysAndValues) throws ClientException {
     try {
-      return querier != null ? createAndSignCommand(commandType,
-              querier.getPrivateKey(), querier.getPublicKey(), keysAndValues)
+      return querier != null ? createAndSignCommandInternal(commandType,
+              querier, keysAndValues)
               : createCommand(commandType, keysAndValues);
     } catch (JSONException e) {
       throw new ClientException("Error encoding message", e);

--- a/src/edu/umass/cs/gnsclient/client/CommandUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/CommandUtils.java
@@ -335,8 +335,7 @@ public class CommandUtils {
    * number of key and value pairs.
    * 
    * @param commandType
-   * @param privateKey
-   * @param publicKey
+   * @param guidEntry
    * @param keysAndValues
    * @return Signed command.
    * @throws ClientException

--- a/src/edu/umass/cs/gnsclient/client/CryptoUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/CryptoUtils.java
@@ -82,7 +82,7 @@ public class CryptoUtils {
     /**
      * Signs a digest of a message using private key of the given guid.
      *
-     * @param privateKey
+     * @param guidEntry
      * @param message
      * @return a signed digest of the message string encoded as a hex string
      * @throws InvalidKeyException
@@ -126,8 +126,7 @@ public class CryptoUtils {
     }
 
     /**
-     * @param privateKey
-     * @param publicKey
+     * @param guidEntry
      * @param message
      * @return Signature encoded as a hex string
      * @throws NoSuchAlgorithmException

--- a/src/edu/umass/cs/gnsclient/client/CryptoUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/CryptoUtils.java
@@ -1,0 +1,190 @@
+package edu.umass.cs.gnsclient.client;
+
+import edu.umass.cs.gnsclient.client.util.GuidEntry;
+import edu.umass.cs.gnscommon.GNSProtocol;
+import edu.umass.cs.gnscommon.exceptions.client.ClientException;
+import edu.umass.cs.gnsserver.main.GNSConfig;
+import edu.umass.cs.utils.SessionKeys;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.xml.bind.DatatypeConverter;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.util.Random;
+import java.util.logging.Level;
+
+
+public class CryptoUtils {
+
+
+
+    static final MessageDigest[] mds = new MessageDigest[Runtime
+            .getRuntime().availableProcessors()];
+    static final Cipher[] ciphers = new Cipher[2 * Runtime.getRuntime()
+                    .availableProcessors()];
+    /* arun: at least as many instances as cores for parallelism. */
+    static Signature[] signatureInstances = new Signature[2 * Runtime
+            .getRuntime().availableProcessors()];
+    static Random random;
+    private static int sigIndex = 0;
+    private static int mdIndex = 0;
+    private static int cipherIndex = 0;
+
+    static {
+        try {
+            for (int i = 0; i < signatureInstances.length; i++) {
+                signatureInstances[i] = Signature
+                        .getInstance(GNSProtocol.SIGNATURE_ALGORITHM.toString());
+            }
+            random = new Random();
+        } catch (NoSuchAlgorithmException e) {
+            GNSConfig.getLogger().log(Level.SEVERE,
+                    "Unable to initialize for authentication:{0}", e);
+        }
+    }
+
+    static {
+        for (int i = 0; i < mds.length; i++) {
+            try {
+                mds[i] = MessageDigest
+                        .getInstance(GNSProtocol.DIGEST_ALGORITHM.toString());
+            } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+                System.exit(1);
+            }
+        }
+    }
+
+    static {
+        for (int i = 0; i < ciphers.length; i++) {
+            try {
+                ciphers[i] = Cipher
+                        .getInstance(GNSProtocol.SECRET_KEY_ALGORITHM.toString());
+            } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+                e.printStackTrace();
+                System.exit(1);
+            }
+        }
+    }
+    private static synchronized Signature getSignatureInstance() {
+      return signatureInstances[sigIndex++ % signatureInstances.length];
+    }
+
+    /**
+     * Signs a digest of a message using private key of the given guid.
+     *
+     * @param privateKey
+     * @param message
+     * @return a signed digest of the message string encoded as a hex string
+     * @throws InvalidKeyException
+     * @throws NoSuchAlgorithmException
+     * @throws SignatureException
+     * @throws java.io.UnsupportedEncodingException
+     *
+     * arun: This method need to be synchronized over the signature
+     * instance, otherwise it will result in corrupted signatures.
+     */
+    public static String signDigestOfMessage(GuidEntry guidEntry,
+            String message) throws ClientException {
+        try {
+            Signature signatureInstance = getSignatureInstance();
+            synchronized (signatureInstance) {
+                signatureInstance.initSign(guidEntry.getPrivateKey());
+                // iOS client uses UTF-8 - should switch to ISO-8859-1 to be consistent with
+                // secret key version
+                signatureInstance.update(message.getBytes("UTF-8"));
+                byte[] signedString = signatureInstance.sign();
+                // We used to encode this as a hex so we could send it with the html without
+                // encoding. Not really necessary anymore for the socket based client,
+                // but the iOS client does as well so we need to keep it like this.
+                // Also note that the secret based method doesn't do this - it just returns a string
+                // using the ISO-8859-1 charset.
+                String result = DatatypeConverter.printHexBinary(signedString);
+                //String result = ByteUtils.toHex(signedString);
+                return result;
+            }
+        } catch (InvalidKeyException | UnsupportedEncodingException | SignatureException e) {
+            throw new ClientException ("Error encoding message", e);
+        }
+    }
+
+    private static MessageDigest getMessageDigestInstance() {
+      return mds[mdIndex++ % mds.length];
+    }
+
+    private static Cipher getCipherInstance() {
+      return ciphers[cipherIndex++ % ciphers.length];
+    }
+
+    /**
+     * @param privateKey
+     * @param publicKey
+     * @param message
+     * @return Signature encoded as a hex string
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     * @throws SignatureException
+     * @throws UnsupportedEncodingException
+     * @throws IllegalBlockSizeException
+     * @throws BadPaddingException
+     * @throws NoSuchPaddingException
+     */
+    public static String signDigestOfMessageSecretKey(GuidEntry guidEntry, String message)
+            throws ClientException {
+        try {
+            SecretKey secretKey = SessionKeys.getOrGenerateSecretKey(guidEntry.getPublicKey(),
+                    guidEntry.getPrivateKey());
+            MessageDigest md = getMessageDigestInstance();
+            byte[] digest;
+            // FIXME: The reason why we use CHARSET should be more throughly documented here.
+            // This might be important for folks writing clients in other languages.
+            byte[] body = message.getBytes(GNSProtocol.CHARSET.toString());
+            synchronized (md) {
+                digest = md.digest(body);
+            }
+            assert (digest != null);
+            Cipher cipher = getCipherInstance();
+            byte[] signature;
+            synchronized (cipher) {
+                cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+                signature = cipher.doFinal(digest);
+            }
+
+            SessionKeys.SecretKeyCertificate skCert = SessionKeys
+                    .getSecretKeyCertificate(guidEntry.getPublicKey());
+            byte[] encodedSKCert = skCert.getEncoded(false);
+
+            // arun: Combining them like this because the rest of the GNS code seems
+            // poorly organized to add more signature related fields in a systematic
+            // manner.
+            byte[] combined = new byte[Short.BYTES + signature.length + Short.BYTES
+                    + encodedSKCert.length];
+            ByteBuffer.wrap(combined)
+                    // signature
+                    .putShort((short) signature.length).put(signature)
+                    // certificate
+                    .putShort((short) encodedSKCert.length).put(encodedSKCert);
+
+            // FIXME: The reason why we use CHARSET should be more throughly documented here.
+            return new String(combined, GNSProtocol.CHARSET.toString());
+        } catch (NoSuchAlgorithmException | InvalidKeyException | SignatureException | NoSuchPaddingException | BadPaddingException | UnsupportedEncodingException | IllegalBlockSizeException e ) {
+            throw new ClientException("Error encoding message message (using secretkey)", e);
+        }
+    }
+
+    /**
+     * @return Random long.
+     */
+    public static String getRandomRequestNonce() {
+      return (random.nextLong() + "");
+    }
+}

--- a/src/edu/umass/cs/gnsclient/client/CryptoUtils.java
+++ b/src/edu/umass/cs/gnsclient/client/CryptoUtils.java
@@ -19,7 +19,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
 import java.security.SignatureException;
-import java.util.Random;
 import java.util.logging.Level;
 
 
@@ -34,7 +33,7 @@ public class CryptoUtils {
     /* arun: at least as many instances as cores for parallelism. */
     static Signature[] signatureInstances = new Signature[2 * Runtime
             .getRuntime().availableProcessors()];
-    static Random random;
+
     private static int sigIndex = 0;
     private static int mdIndex = 0;
     private static int cipherIndex = 0;
@@ -45,7 +44,6 @@ public class CryptoUtils {
                 signatureInstances[i] = Signature
                         .getInstance(GNSProtocol.SIGNATURE_ALGORITHM.toString());
             }
-            random = new Random();
         } catch (NoSuchAlgorithmException e) {
             GNSConfig.getLogger().log(Level.SEVERE,
                     "Unable to initialize for authentication:{0}", e);
@@ -180,10 +178,4 @@ public class CryptoUtils {
         }
     }
 
-    /**
-     * @return Random long.
-     */
-    public static String getRandomRequestNonce() {
-      return (random.nextLong() + "");
-    }
 }

--- a/src/edu/umass/cs/gnsclient/client/deprecated/examples/ClientAsynchExample.java
+++ b/src/edu/umass/cs/gnsclient/client/deprecated/examples/ClientAsynchExample.java
@@ -101,14 +101,12 @@ public class ClientAsynchExample {
               + "\"gibberish\":{\"meiny\":\"bloop\",\"einy\":\"floop\"},"
               + "\"location\":\"work\",\"name\":\"frank\"}");
       command = createAndSignCommand(CommandType.ReplaceUserJSON,
-              accountGuidEntry.getPrivateKey(),
-              accountGuidEntry.getPublicKey(),
+              accountGuidEntry,
               GNSProtocol.GUID.toString(), accountGuidEntry.getGuid(), GNSProtocol.USER_JSON.toString(), json.toString(),
               GNSProtocol.WRITER.toString(), accountGuidEntry.getGuid());
     } else {
       command = createAndSignCommand(CommandType.Read,
-              accountGuidEntry.getPrivateKey(),
-              accountGuidEntry.getPublicKey(),
+              accountGuidEntry,
               GNSProtocol.GUID.toString(), accountGuidEntry.getGuid(), GNSProtocol.FIELD.toString(), "occupation",
               GNSProtocol.READER.toString(), accountGuidEntry.getGuid());
     }

--- a/src/edu/umass/cs/gnsclient/client/http/HttpClient.java
+++ b/src/edu/umass/cs/gnsclient/client/http/HttpClient.java
@@ -20,6 +20,7 @@
 package edu.umass.cs.gnsclient.client.http;
 
 import edu.umass.cs.gnsclient.client.CommandUtils;
+import edu.umass.cs.gnsclient.client.CryptoUtils;
 import edu.umass.cs.gnsclient.client.GNSClientConfig;
 
 import java.io.BufferedReader;
@@ -1836,9 +1837,9 @@ public class HttpClient {
       PublicKey publicKey = keypair.getPublic();
       String signatureString;
       if (Config.getGlobalBoolean(GNSClientConfig.GNSCC.ENABLE_SECRET_KEY)) {
-        signatureString = CommandUtils.signDigestOfMessage(privateKey, publicKey, canonicalJSON);
+        signatureString = CryptoUtils.signDigestOfMessage(privateKey, publicKey, canonicalJSON);
       } else {
-        signatureString = CommandUtils.signDigestOfMessage(privateKey, canonicalJSON);
+        signatureString = CryptoUtils.signDigestOfMessage(privateKey, canonicalJSON);
       }
       String signaturePart = KEYSEP + GNSProtocol.SIGNATURE.toString()
               // Base64 encode the signature first since it's guaranteed to be a lot of non-ASCII characters

--- a/src/edu/umass/cs/gnsclient/client/http/HttpClient.java
+++ b/src/edu/umass/cs/gnsclient/client/http/HttpClient.java
@@ -1837,9 +1837,9 @@ public class HttpClient {
       PublicKey publicKey = keypair.getPublic();
       String signatureString;
       if (Config.getGlobalBoolean(GNSClientConfig.GNSCC.ENABLE_SECRET_KEY)) {
-        signatureString = CryptoUtils.signDigestOfMessage(privateKey, publicKey, canonicalJSON);
+        signatureString = CryptoUtils.signDigestOfMessageSecretKey(guid, canonicalJSON);
       } else {
-        signatureString = CryptoUtils.signDigestOfMessage(privateKey, canonicalJSON);
+        signatureString = CryptoUtils.signDigestOfMessage(guid, canonicalJSON);
       }
       String signaturePart = KEYSEP + GNSProtocol.SIGNATURE.toString()
               // Base64 encode the signature first since it's guaranteed to be a lot of non-ASCII characters
@@ -1858,8 +1858,7 @@ public class HttpClient {
       }
       // Finally return everything
       return encodedString.toString() + signaturePart + debuggingPart;
-    } catch (JSONException | UnsupportedEncodingException | NoSuchAlgorithmException | InvalidKeyException | SignatureException | IllegalBlockSizeException |
-            BadPaddingException | NoSuchPaddingException e) {
+    } catch (JSONException | UnsupportedEncodingException e) {
       throw new ClientException("Error encoding message", e);
     }
   }

--- a/src/edu/umass/cs/gnsclient/client/testing/ThroughputAsynchMultiClientTest.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/ThroughputAsynchMultiClientTest.java
@@ -494,8 +494,7 @@ public class ThroughputAsynchMultiClientTest {
               GNSProtocol.READER.toString(), null);
     } else {
       command = createAndSignCommand(CommandType.Read,
-              reader.getPrivateKey(),
-              reader.getPublicKey(),
+              reader,
               GNSProtocol.GUID.toString(), targetGuid, GNSProtocol.FIELD.toString(), field,
               GNSProtocol.READER.toString(), reader.getGuid());
     }
@@ -506,8 +505,7 @@ public class ThroughputAsynchMultiClientTest {
   private static CommandPacket createUpdateCommandPacket(GNSClient client, String targetGuid, JSONObject json, GuidEntry writer) throws Exception {
     JSONObject command;
     command = createAndSignCommand(CommandType.ReplaceUserJSON,
-            writer.getPrivateKey(),
-            writer.getPublicKey(),
+            writer,
             GNSProtocol.GUID.toString(), targetGuid, json.toString(),
             GNSProtocol.WRITER.toString(), writer.getGuid());
     return new CommandPacket(-1, command);


### PR DESCRIPTION
This change requires a detailed writeup

**What this change is doing:**
This change moves usages of `javax.crypto` and related classes in `GNSClient` to a new class `CryptoUtils`. This change aims to make `CryptoUtils` look like a blackbox to other classes so that all methods of `CryptoUtils` take in a `GuidEntry` (not `PublicKey`/`PrivateKey`) and return a string (in some encoding).

**Why is this required:**
j2objc does not support translating crypto related classes to Objective C. This also means that we will not be able to create an instance of Java's `PublicKey` in Objective C. We need to have a nice interface between translated iOS code and native iOS code. `CryptoUtils` provides that interface. The solution is to implement everything in `CryptoUtils` natively, so that there is no `PublicKey`/`PrivateKey` transfer between translated code and native code.

**Next step:**
This change is still not complete. There is still some code in client that directly uses `PublicKey`. I'll next work on making such accesses through `CryptoUtils` so that native implementation can take care of this. This PR can be merged after approval, I'll create a new PR for more changes.