### PR TITLE
Move `getRequestStatic` from `GNSApp` to `GNSAppUtil`

### DIFF
--- a/src/edu/umass/cs/gnsclient/client/GNSClient.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSClient.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 
+import edu.umass.cs.gnsserver.gnsapp.GNSAppUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -42,7 +43,6 @@ import edu.umass.cs.gnscommon.exceptions.client.ClientException;
 import edu.umass.cs.gnscommon.packets.CommandPacket;
 import edu.umass.cs.gnscommon.packets.PacketUtils;
 import edu.umass.cs.gnscommon.packets.ResponsePacket;
-import edu.umass.cs.gnsserver.gnsapp.GNSApp;
 import edu.umass.cs.gnsserver.gnsapp.packet.InternalCommandPacket;
 import edu.umass.cs.gnsserver.gnsapp.packet.Packet;
 import edu.umass.cs.gnsserver.main.GNSConfig;
@@ -594,7 +594,7 @@ public class GNSClient {
 		@Override
 		public Request getRequest(byte[] bytes, NIOHeader header)
 				throws RequestParseException {
-			return GNSApp.getRequestStatic(bytes, header, unstringer);
+			return GNSAppUtil.getRequestStatic(bytes, header, unstringer);
 		}
 	} // End of AsyncClient
 

--- a/src/edu/umass/cs/gnsserver/gnsapp/GNSAppUtil.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/GNSAppUtil.java
@@ -1,0 +1,84 @@
+package edu.umass.cs.gnsserver.gnsapp;
+
+import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.gnscommon.packets.CommandPacket;
+import edu.umass.cs.gnsserver.gnsapp.packet.Packet;
+import edu.umass.cs.nio.JSONPacket;
+import edu.umass.cs.nio.MessageExtractor;
+import edu.umass.cs.nio.interfaces.Byteable;
+import edu.umass.cs.nio.interfaces.Stringifiable;
+import edu.umass.cs.nio.nioutils.NIOHeader;
+import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
+import edu.umass.cs.utils.DelayProfiler;
+import edu.umass.cs.utils.Util;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+
+/*
+ * The reason why this is in a new class instead of GNSApp is to avoid additional dependencies
+ * while translating code to Objective C.
+ */
+
+
+public class GNSAppUtil {
+    /**
+     * This method avoids an unnecessary restringification (as is the case with
+     * {@link GNSApp#getRequest(String)} above) by decoding the JSON, stamping it with
+     * the sender information, and then creating a packet out of it.
+     *
+     * @param msgBytes
+     * @param header
+     * @param unstringer
+     * @return Request constructed from msgBytes.
+     * @throws RequestParseException
+     */
+    public static Request getRequestStatic(byte[] msgBytes, NIOHeader header,
+                                           Stringifiable<String> unstringer) throws RequestParseException {
+      Request request = null;
+      try {
+        long t = System.nanoTime();
+        if (JSONPacket.couldBeJSON(msgBytes)) {
+          JSONObject json = new JSONObject(new String(msgBytes,
+                  NIOHeader.CHARSET));
+          MessageExtractor.stampAddressIntoJSONObject(header.sndr,
+                  header.rcvr, json);
+          request = (Request) Packet.createInstance(json, unstringer);
+        } else {
+          // parse non-JSON byteified form
+          return fromBytes(msgBytes);
+        }
+        if (Util.oneIn(100)) {
+          DelayProfiler.updateDelayNano(
+                  "getRequest." + request.getRequestType(), t);
+        }
+      } catch (JSONException | UnsupportedEncodingException e) {
+        throw new RequestParseException(e);
+      }
+      return request;
+    }
+
+    /**
+     * This method should invert the implementation of the
+     * {@link Byteable#toBytes()} method for GNSApp packets.
+     *
+     * @param msgBytes
+     * @return a request
+     * @throws RequestParseException
+     */
+    private static Request fromBytes(byte[] msgBytes)
+            throws RequestParseException {
+      switch (Packet.PacketType.getPacketType(ByteBuffer.wrap(msgBytes)
+              .getInt())) {
+        case COMMAND:
+          return new CommandPacket(msgBytes);
+        /* Currently only CommandPacket is Byteable, so we shouldn't come
+               * here for anything else. */
+        default:
+          throw new RequestParseException(new RuntimeException(
+                  "Unrecognizable request type"));
+      }
+    }
+}


### PR DESCRIPTION
`GNSClient` uses `GNSApp.getRequestStatic()`. This forces `GNSClient` to depend on `GNSApp` (and all its transitive dependencies) even if it is using a single method. Moving the method in question to a new class avoids this dependency.