### PR TITLE
Reduce the number of Travis test iterations from 10 to 7

### DIFF
--- a/scripts/travis_checks.sh
+++ b/scripts/travis_checks.sh
@@ -17,7 +17,7 @@ script_dir=`pwd`
 
 # Run ant test 10 times
 # A single failure will flag a Travis build failure
-test_repeat=10
+test_repeat=7 # Temporary change, replace with 10 ASAP
 
 # The warning_counts file keeps track of previous warning counts
 wcount_file="warning_counts"


### PR DESCRIPTION
Tests are timing out due to the recent switch from integration tests to singletests. I'll be reducing the number of times tests are repeated temporarily until test optimizations are done. 7 iterations looks like a good number as each iteration is taking ~5mins. Travis times out at 49mins