### PR TITLE
Added selectRecords methods to client which return a list of full or partial records.

### DIFF
--- a/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Set;
 import org.json.JSONException;
 import edu.umass.cs.gnscommon.GNSProtocol;
+import java.util.List;
 
 /**
  *
@@ -413,6 +414,65 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray selectQuery(GuidEntry reader, String query) throws ClientException, IOException {
     return execute(GNSCommand.selectQuery(reader, query)).getResultJSONArray();
+  }
+  
+  /**
+   * Selects all records that match query. Returns the result of the query as
+   * a JSONArray of guids. Requires that all fields accessed be world readable.
+   *
+   * The query syntax is described here:
+   * https://gns.name/wiki/index.php?title=Query_Syntax
+   *
+   * Currently there are two predefined field names in the GNS client (this is
+   * in edu.umass.cs.gnsclient.client.GNSCommandProtocol):
+   * GNSProtocol.LOCATION_FIELD_NAME.toString() = "geoLocation";
+   * Defined as a "2d" index in the database.
+   * GNSProtocol.IPADDRESS_FIELD_NAME.toString() = "netAddress";
+   *
+   * There are links in the wiki page above to find the exact syntax for
+   * querying spacial coordinates.
+   *
+   * @param query
+   * - the query
+   * @param fields
+   * @return - a JSONArray of guids
+   * @throws edu.umass.cs.gnscommon.exceptions.client.ClientException
+   * if a protocol error occurs or the list cannot be parsed
+   * @throws java.io.IOException
+   * if a communication error occurs
+   */
+  public JSONArray selectQueryProjection(String query, List<String> fields) throws ClientException, IOException {
+    return execute(GNSCommand.selectQueryProjection(query, fields)).getResultJSONArray();
+  }
+
+  /**
+   * Selects all records that match query. Returns the result of the query as
+   * a JSONArray of guids.
+   *
+   * The query syntax is described here:
+   * https://gns.name/wiki/index.php?title=Query_Syntax
+   *
+   * Currently there are two predefined field names in the GNS client (this is
+   * in edu.umass.cs.gnsclient.client.GNSCommandProtocol):
+   * GNSProtocol.LOCATION_FIELD_NAME.toString() = "geoLocation";
+   * Defined as a "2d" index in the database.
+   * GNSProtocol.IPADDRESS_FIELD_NAME.toString() = "netAddress";
+   *
+   * There are links in the wiki page above to find the exact syntax for
+   * querying spacial coordinates.
+   *
+   * @param reader
+   * @param query
+   * - the query
+   * @param fields
+   * @return - a JSONArray of guids
+   * @throws edu.umass.cs.gnscommon.exceptions.client.ClientException
+   * if a protocol error occurs or the list cannot be parsed
+   * @throws java.io.IOException
+   * if a communication error occurs
+   */
+  public JSONArray selectQueryProjection(GuidEntry reader, String query, List<String> fields) throws ClientException, IOException {
+    return execute(GNSCommand.selectQueryProjection(reader, query, fields)).getResultJSONArray();
   }
 
   /**

--- a/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
@@ -417,8 +417,12 @@ public class GNSClientCommands extends GNSClient {
   }
   
   /**
-   * Selects all records that match query. Returns the result of the query as
-   * a JSONArray of guids. Requires that all fields accessed be world readable.
+   * Returns a list of all guid records that match the {@code query}.
+   * The {@code fields} parameter is a list of the fields that
+   * should be included in the returned records. {@code null}
+   * means return all fields.
+   * 
+   * Requires that all fields accessed be world readable.
    *
    * The query syntax is described here:
    * https://gns.name/wiki/index.php?title=Query_Syntax
@@ -441,13 +445,15 @@ public class GNSClientCommands extends GNSClient {
    * @throws java.io.IOException
    * if a communication error occurs
    */
-  public JSONArray selectQueryProjection(String query, List<String> fields) throws ClientException, IOException {
-    return execute(GNSCommand.selectQueryProjection(query, fields)).getResultJSONArray();
+  public JSONArray selectRecords(String query, List<String> fields) throws ClientException, IOException {
+    return execute(GNSCommand.selectRecords(query, fields)).getResultJSONArray();
   }
 
   /**
-   * Selects all records that match query. Returns the result of the query as
-   * a JSONArray of guids.
+   * Returns a list of all guid records that match the {@code query}.
+   * The {@code fields} parameter is a list of the fields that
+   * should be included in the returned records.{@code null}
+   * means return all fields.
    *
    * The query syntax is described here:
    * https://gns.name/wiki/index.php?title=Query_Syntax
@@ -471,8 +477,8 @@ public class GNSClientCommands extends GNSClient {
    * @throws java.io.IOException
    * if a communication error occurs
    */
-  public JSONArray selectQueryProjection(GuidEntry reader, String query, List<String> fields) throws ClientException, IOException {
-    return execute(GNSCommand.selectQueryProjection(reader, query, fields)).getResultJSONArray();
+  public JSONArray selectRecords(GuidEntry reader, String query, List<String> fields) throws ClientException, IOException {
+    return execute(GNSCommand.selectRecords(reader, query, fields)).getResultJSONArray();
   }
 
   /**

--- a/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
@@ -438,7 +438,7 @@ public class GNSClientCommands extends GNSClient {
    *
    * @param query
    * - the query
-   * @param fields
+   * @param fields A list of fields or null meaning all fields
    * @return - a JSONArray of guids
    * @throws edu.umass.cs.gnscommon.exceptions.client.ClientException
    * if a protocol error occurs or the list cannot be parsed
@@ -470,7 +470,7 @@ public class GNSClientCommands extends GNSClient {
    * @param reader
    * @param query
    * - the query
-   * @param fields
+   * @param fields A list of fields or null meaning all fields
    * @return - a JSONArray of guids
    * @throws edu.umass.cs.gnscommon.exceptions.client.ClientException
    * if a protocol error occurs or the list cannot be parsed

--- a/src/edu/umass/cs/gnsclient/client/GNSCommand.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSCommand.java
@@ -32,9 +32,7 @@ import edu.umass.cs.gnsclient.client.util.KeyPairUtils;
 import edu.umass.cs.gnsclient.client.util.Password;
 import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnscommon.CommandType;
-import edu.umass.cs.gnscommon.SharedGuidUtils;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
-import edu.umass.cs.gnscommon.exceptions.client.InvalidGuidException;
 import edu.umass.cs.gnscommon.packets.AdminCommandPacket;
 import edu.umass.cs.gnscommon.packets.CommandPacket;
 import edu.umass.cs.gnscommon.utils.Base64;
@@ -1571,6 +1569,66 @@ public class GNSCommand extends CommandPacket {
     return getCommand(CommandType.SelectQuery, reader,
             GNSProtocol.GUID.toString(), reader.getGuid(),
             GNSProtocol.QUERY.toString(), query);
+  }
+
+  /**
+   * Selects all guid records that match {@code query}. The result type of the
+   * execution result of this query is {@link CommandResultType#LIST}.
+   * Requires all fields accessed to be world readable.
+   *
+   * The query syntax is described here:
+   * https://gns.name/wiki/index.php?title=Query_Syntax
+   *
+   * There are some predefined field names such as
+   * {@link edu.umass.cs.gnscommon.GNSProtocol#LOCATION_FIELD_NAME} and
+   * {@link edu.umass.cs.gnscommon.GNSProtocol#IPADDRESS_FIELD_NAME} that are indexed by
+   * default.
+   *
+   * There are links in the wiki page above to find the exact syntax for
+   * querying spatial coordinates.
+   *
+   * @param query
+   * The select query being issued.
+   * @param fields
+   * @return CommandPacket
+   * @throws ClientException
+   */
+  public static final CommandPacket selectQueryProjection(String query, List<String> fields)
+          throws ClientException {
+    return getCommand(CommandType.SelectQuery,
+            GNSProtocol.QUERY.toString(), query,
+            GNSProtocol.FIELDS.toString(), fields);
+  }
+
+  /**
+   * Selects all guid records that match {@code query}. The result type of the
+   * execution result of this query is {@link CommandResultType#LIST}.
+   *
+   * The query syntax is described here:
+   * https://gns.name/wiki/index.php?title=Query_Syntax
+   *
+   * There are some predefined field names such as
+   * {@link edu.umass.cs.gnscommon.GNSProtocol#LOCATION_FIELD_NAME} and
+   * {@link edu.umass.cs.gnscommon.GNSProtocol#IPADDRESS_FIELD_NAME} that are indexed by
+   * default.
+   *
+   * There are links in the wiki page above to find the exact syntax for
+   * querying spatial coordinates.
+   *
+   * @param reader
+   * @param query
+   * The select query being issued.
+   * @param fields
+   * @return CommandPacket
+   * @throws ClientException
+   */
+  public static final CommandPacket selectQueryProjection(GuidEntry reader, String query, List<String> fields)
+          throws ClientException {
+    return getCommand(CommandType.SelectQuery, reader,
+            GNSProtocol.GUID.toString(), reader.getGuid(),
+            GNSProtocol.QUERY.toString(), query,
+            GNSProtocol.FIELDS.toString(), fields
+    );
   }
 
   /**

--- a/src/edu/umass/cs/gnsclient/client/GNSCommand.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSCommand.java
@@ -1594,7 +1594,7 @@ public class GNSCommand extends CommandPacket {
    *
    * @param query
    * The select query being issued.
-   * @param fields
+   * @param fields A list of fields or null meaning all fields
    * @return CommandPacket
    * @throws ClientException
    */
@@ -1625,7 +1625,7 @@ public class GNSCommand extends CommandPacket {
    * @param reader
    * @param query
    * The select query being issued.
-   * @param fields
+   * @param fields A list of fields or null meaning all fields
    * @return CommandPacket
    * @throws ClientException
    */

--- a/src/edu/umass/cs/gnsclient/client/GNSCommand.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSCommand.java
@@ -1572,8 +1572,13 @@ public class GNSCommand extends CommandPacket {
   }
 
   /**
-   * Selects all guid records that match {@code query}. The result type of the
-   * execution result of this query is {@link CommandResultType#LIST}.
+   * Selects all guid records that match the {@code query}.
+   * The {@code fields} parameter is a list of the fields that
+   * should be included in the returned records. {@code null}
+   * means return all fields.
+   * 
+   * The result type of the execution result of this query 
+   * is {@link CommandResultType#LIST}.
    * Requires all fields accessed to be world readable.
    *
    * The query syntax is described here:
@@ -1593,16 +1598,18 @@ public class GNSCommand extends CommandPacket {
    * @return CommandPacket
    * @throws ClientException
    */
-  public static final CommandPacket selectQueryProjection(String query, List<String> fields)
+  public static final CommandPacket selectRecords(String query, List<String> fields)
           throws ClientException {
     return getCommand(CommandType.SelectQuery,
             GNSProtocol.QUERY.toString(), query,
-            GNSProtocol.FIELDS.toString(), fields);
+            GNSProtocol.FIELDS.toString(), fields == null ? GNSProtocol.ENTIRE_RECORD : fields);
   }
 
   /**
-   * Selects all guid records that match {@code query}. The result type of the
-   * execution result of this query is {@link CommandResultType#LIST}.
+   * Selects all guid records that match the {@code query}.
+   * The {@code fields} parameter is a list of the fields that
+   * should be included in the returned records. {@code null}
+   * means return all fields.
    *
    * The query syntax is described here:
    * https://gns.name/wiki/index.php?title=Query_Syntax
@@ -1622,12 +1629,12 @@ public class GNSCommand extends CommandPacket {
    * @return CommandPacket
    * @throws ClientException
    */
-  public static final CommandPacket selectQueryProjection(GuidEntry reader, String query, List<String> fields)
+  public static final CommandPacket selectRecords(GuidEntry reader, String query, List<String> fields)
           throws ClientException {
     return getCommand(CommandType.SelectQuery, reader,
             GNSProtocol.GUID.toString(), reader.getGuid(),
             GNSProtocol.QUERY.toString(), query,
-            GNSProtocol.FIELDS.toString(), fields
+            GNSProtocol.FIELDS.toString(), fields == null ? GNSProtocol.ENTIRE_RECORD : fields
     );
   }
 

--- a/src/edu/umass/cs/gnsclient/client/bugreports/SequentialCreateFieldTimeout.java
+++ b/src/edu/umass/cs/gnsclient/client/bugreports/SequentialCreateFieldTimeout.java
@@ -29,6 +29,15 @@ import edu.umass.cs.utils.Util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author Brendan

--- a/src/edu/umass/cs/gnsclient/client/bugreports/SequentialCreateFieldTimeout.java
+++ b/src/edu/umass/cs/gnsclient/client/bugreports/SequentialCreateFieldTimeout.java
@@ -29,15 +29,6 @@ import edu.umass.cs.utils.Util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 /**
  * @author Brendan

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveACL.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveACL.java
@@ -22,6 +22,12 @@ import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commandSupport.ActiveCode;
 import edu.umass.cs.utils.DefaultTest;
 import edu.umass.cs.utils.Util;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * This test checks when a GNS user does not remove his ALL_FIELD ACL,

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveACL.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveACL.java
@@ -1,9 +1,5 @@
 package edu.umass.cs.gnsclient.client.testing.activecode;
 
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -22,10 +18,6 @@ import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commandSupport.ActiveCode;
 import edu.umass.cs.utils.DefaultTest;
 import edu.umass.cs.utils.Util;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveCodeRemoteQueryClient.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveCodeRemoteQueryClient.java
@@ -19,6 +19,12 @@ import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnscommon.GNSProtocol;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
 import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commandSupport.ActiveCode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author gaozy

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveCodeRemoteQueryClient.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveCodeRemoteQueryClient.java
@@ -1,7 +1,5 @@
 package edu.umass.cs.gnsclient.client.testing.activecode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,10 +17,6 @@ import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnscommon.GNSProtocol;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
 import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commandSupport.ActiveCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/src/edu/umass/cs/gnscommon/CommandType.java
+++ b/src/edu/umass/cs/gnscommon/CommandType.java
@@ -39,180 +39,180 @@ public enum CommandType {
   Append(110, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.Append",
           CommandResultType.NULL, true, false,
           "Appends the value onto the field for the given GUID. "
-                  + "Treats the list as a set, removing duplicates. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Treats the list as a set, removing duplicates. "
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   AppendList(111, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendList",
           CommandResultType.NULL, true, false,
           "Appends the value onto of this field for the given GUID. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   AppendListUnsigned(113, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendListUnsigned",
           CommandResultType.NULL, true, false,
           "Appends the value onto of this field for the given GUID. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be world writeable as this command does not specify "
-                  + "the writer and is not signed.",
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be world writeable as this command does not specify "
+          + "the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   AppendListWithDuplication(114, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendListWithDuplication",
           CommandResultType.NULL, true, false,
           "Appends the values onto this field for the given GUID. "
-                  + "Treats the list as a list, allows dupicates. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Treats the list as a list, allows dupicates. "
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   AppendListWithDuplicationUnsigned(116, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendListWithDuplicationUnsigned",
           CommandResultType.NULL, true, false,
           "Appends the values onto of this field for the given GUID. "
-                  + "Treats the list as a list, allows dupicate. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Treats the list as a list, allows dupicate. "
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   AppendOrCreate(120, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendOrCreate",
           CommandResultType.NULL, true, false,
           "Adds a field to the GNS for the given guid if it doesn't not exist "
-                  + "otherwise append value onto existing value. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "otherwise append value onto existing value. "
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   AppendOrCreateList(121, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendOrCreateList",
           CommandResultType.NULL, true, false,
           "Adds a field to the GNS for the given guid if it doesn not exist "
-                  + "otherwise appends values onto existing value. "
-                  + "Value is a list of items formated as a JSON list. Field must be writeable by the WRITER guid.",
+          + "otherwise appends values onto existing value. "
+          + "Value is a list of items formated as a JSON list. Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   AppendOrCreateListUnsigned(123, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendOrCreateListUnsigned",
           CommandResultType.NULL, true, false,
           "Adds a field to the GNS for the given guid if it doesn not exist "
-                  + "otherwise appends values onto existing value. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be world writeable as this command does not specify the "
-                  + "writer and is not signed.",
+          + "otherwise appends values onto existing value. "
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be world writeable as this command does not specify the "
+          + "writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   AppendOrCreateUnsigned(125, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendOrCreateUnsigned",
           CommandResultType.NULL, true, false,
           "Adds a field to the GNS for the given guid if it doesn't not exist "
-                  + "otherwise append value onto existing value. "
-                  + "Field must be world writeable as this command does not specify "
-                  + "the writer and is not signed.",
+          + "otherwise append value onto existing value. "
+          + "Field must be world writeable as this command does not specify "
+          + "the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   AppendUnsigned(131, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendUnsigned",
           CommandResultType.NULL, true, false,
           "Appends the value onto the field for the given GUID. "
-                  + "Treats the list as a set, removing duplicates."
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Treats the list as a set, removing duplicates."
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   AppendWithDuplication(132, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendWithDuplication",
           CommandResultType.NULL, true, false,
           "Appends the values onto this field for the given GUID. "
-                  + "Treats the list as a list, allows dupicates. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Treats the list as a list, allows dupicates. "
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   AppendWithDuplicationUnsigned(134, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.AppendWithDuplicationUnsigned",
           CommandResultType.NULL, true, false,
           "Appends the values onto this field for the given GUID. "
-                  + "Treats the list as a list, allows dupicates. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Treats the list as a list, allows dupicates. "
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   Clear(140, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.Clear",
           CommandResultType.NULL, true, false,
           "Clears the field from the GNS for the given GUID. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   ClearUnsigned(142, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ClearUnsigned",
           CommandResultType.NULL, true, false,
           "Clears the field from the GNS for the given guid after authenticating that "
-                  + "GUID making request has access authority. "
-                  + "Field must be world writeable as this command does not specify "
-                  + "the writer and is not signed.",
+          + "GUID making request has access authority. "
+          + "Field must be world writeable as this command does not specify "
+          + "the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.WRITER.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.WRITER.toString()}, new String[]{}),
   /**
    *
    */
@@ -220,24 +220,24 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Adds a field to the GNS for the given GUID. Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           //optional parameters
           new String[]{GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString()}),
+            GNSProtocol.WRITER.toString()}),
   /**
    *
    */
   CreateEmpty(151, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.CreateEmpty",
           CommandResultType.NULL, true, false,
           "Adds an empty field to the GNS for the given GUID. Field must be writeable by the WRITER guid."
-                  + "A shorthand for Create with an missing value field.",
+          + "A shorthand for Create with an missing value field.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{}),
   /**
    *
@@ -245,12 +245,12 @@ public enum CommandType {
   CreateList(153, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.CreateList",
           CommandResultType.NULL, true, false,
           "Adds a field to the GNS for the given GUID. Value is a list of items "
-                  + "formated as a JSON list. Field must be writeable by the WRITER guid.",
+          + "formated as a JSON list. Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // Optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
@@ -259,31 +259,31 @@ public enum CommandType {
   Read(160, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.Read",
           CommandResultType.MAP, true, false,
           "Returns the value for the key from the GNS for the given guid after authenticating that "
-                  + "READER making request has access authority. "
-                  + "Field can use dot notation to access subfields. "
-                  + "Specify +ALL+ as the <field> to return all fields as a JSON object.",
+          + "READER making request has access authority. "
+          + "Field can use dot notation to access subfields. "
+          + "Specify +ALL+ as the <field> to return all fields as a JSON object.",
           new String[]{GNSProtocol.GUID.toString()},
           // Optional parameters
           new String[]{GNSProtocol.FIELD.toString(),
-                  GNSProtocol.FIELDS.toString(),
-                  GNSProtocol.READER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.FIELDS.toString(),
+            GNSProtocol.READER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   ReadSecured(161, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.secured.ReadSecured",
           CommandResultType.MAP, true, false,
           "Returns the value for the key from the GNS for the given guid after authenticating that "
-                  + "READER making request has access authority. "
-                  + "Field can use dot notation to access subfields. "
-                  + "Specify +ALL+ as the <field> to return all fields as a JSON object. "
-                  + "Sent on the mutual auth channel. "
-                  + "Can only be sent from a client that has the correct ssl keys.",
+          + "READER making request has access authority. "
+          + "Field can use dot notation to access subfields. "
+          + "Specify +ALL+ as the <field> to return all fields as a JSON object. "
+          + "Sent on the mutual auth channel. "
+          + "Can only be sent from a client that has the correct ssl keys.",
           new String[]{GNSProtocol.GUID.toString()},
           // Optional parameters
           new String[]{GNSProtocol.FIELD.toString(),
-                  GNSProtocol.FIELDS.toString()},
+            GNSProtocol.FIELDS.toString()},
           CommandFlag.MUTUAL_AUTH // This is important - without this the command isn't secure.
   ),
   /**
@@ -292,182 +292,182 @@ public enum CommandType {
   ReadUnsigned(162, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReadUnsigned",
           CommandResultType.MAP, true, false,
           "Returns the value for the key from the GNS for the given guid. Does not require authentication but "
-                  + "field must be set to be readable by everyone. "
-                  + "Specify +ALL+ as the <field> to return all fields. ",
+          + "field must be set to be readable by everyone. "
+          + "Specify +ALL+ as the <field> to return all fields. ",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString()}, new String[]{}),
   /**
    *
    */
   ReadMultiField(163, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReadMultiField",
           CommandResultType.MAP, true, false,
           "Returns multiple values for the keys from the GNS for the given guid after "
-                  + "authenticating that READER making request has access authority. "
-                  + "Fields can use dot notation to access subfields.",
+          + "authenticating that READER making request has access authority. "
+          + "Fields can use dot notation to access subfields.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELDS.toString(),
-                  GNSProtocol.READER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELDS.toString(),
+            GNSProtocol.READER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   ReadMultiFieldUnsigned(164, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReadMultiFieldUnsigned",
           CommandResultType.MAP, true, false,
           "Returns multiple values for the keys from the GNS for the given guid after "
-                  + "authenticating that READER making request has access authority. "
-                  + "Fields can use dot notation to access subfields.",
+          + "authenticating that READER making request has access authority. "
+          + "Fields can use dot notation to access subfields.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELDS.toString()}, new String[]{}),
+            GNSProtocol.FIELDS.toString()}, new String[]{}),
   /**
    *
    */
   ReadArray(170, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReadArray",
           CommandResultType.LIST, true, false,
           "Returns the value of the field as an array from the GNS for the given guid after authenticating "
-                  + "that READER making request has access authority. "
-                  + "Values are always returned as a JSON list. "
-                  + "Specify +ALL+ as the <field> to return all fields as a JSON object.",
+          + "that READER making request has access authority. "
+          + "Values are always returned as a JSON list. "
+          + "Specify +ALL+ as the <field> to return all fields as a JSON object.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString()},
+            GNSProtocol.FIELD.toString()},
           // optional parameters
           new String[]{GNSProtocol.READER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   ReadArrayOne(171, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReadArrayOne",
           CommandResultType.STRING, true, false,
           "Returns the first value of the field as an array from the GNS for the given guid after authenticating "
-                  + "that the READER has access authority. Treats the value of field "
-                  + "as a singleton item and returns that item. "
-                  + "Specify +ALL+ as the <field> to return all fields. ",
+          + "that the READER has access authority. Treats the value of field "
+          + "as a singleton item and returns that item. "
+          + "Specify +ALL+ as the <field> to return all fields. ",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.READER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.READER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   ReadArrayOneUnsigned(173, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReadArrayOneUnsigned",
           CommandResultType.STRING, true, false,
           "Returns the first value of the field as an array from the GNS for the given guid. "
-                  + "Does not require authentication"
-                  + " but field must be set to be readable by everyone. "
-                  + "Treats the value of field as a singleton item and returns that item. "
-                  + "Specify +ALL+ as the <field> to return all fields. ",
+          + "Does not require authentication"
+          + " but field must be set to be readable by everyone. "
+          + "Treats the value of field as a singleton item and returns that item. "
+          + "Specify +ALL+ as the <field> to return all fields. ",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString()}, new String[]{}),
   /**
    *
    */
   ReadArrayUnsigned(175, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReadArrayUnsigned",
           CommandResultType.LIST, true, false,
           "Returns the value of the field as an array from the GNS. Does not require authentication but "
-                  + "field must be set to be readable by everyone. Values are always returned as a JSON list. "
-                  + "Specify +ALL+ as the <field> to return all fields. ",
+          + "field must be set to be readable by everyone. Values are always returned as a JSON list. "
+          + "Specify +ALL+ as the <field> to return all fields. ",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString()}, new String[]{}),
   /**
    *
    */
   Remove(180, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.Remove",
           CommandResultType.NULL, true, false,
           "Removes the value from the field for the given guid after authenticating that "
-                  + "WRITER making request has access authority. "
-                  + "Values are always returned as a JSON list. "
-                  + "Specify +ALL+ as the <field> to return all fields as a JSON object.",
+          + "WRITER making request has access authority. "
+          + "Values are always returned as a JSON list. "
+          + "Specify +ALL+ as the <field> to return all fields as a JSON object.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   RemoveList(181, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.RemoveList",
           CommandResultType.NULL, true, false,
           "Removes all the values from the field for the given GUID. "
-                  + "Value is a list of items formated as a JSON list. Field must be writeable by the WRITER guid.",
+          + "Value is a list of items formated as a JSON list. Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   RemoveListUnsigned(183, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.RemoveListUnsigned",
           CommandResultType.NULL, true, false,
           "Removes all the values from the field for the given GUID. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   RemoveUnsigned(185, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.RemoveUnsigned",
           CommandResultType.NULL, true, false,
           "Removes the value from the field for the given GUID. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   Replace(190, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.Replace",
           CommandResultType.NULL, true, false,
           "Replaces the current value for the field from the GNS for the given guid with the given value. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   ReplaceList(191, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceList",
           CommandResultType.NULL, true, false,
           "Replaces the current value for the field from the GNS for the given guid with the given values. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   ReplaceListUnsigned(193, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceListUnsigned",
           CommandResultType.NULL, true, false,
           "Replaces the current value value for the field from the GNS for the given guid with the given values. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()}, new String[]{}),
   /**
    *
    */
   ReplaceOrCreate(210, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceOrCreate",
           CommandResultType.NULL, true, false,
           "Adds field with the value to the GNS for the given guid if it doesn not exist otherwise "
-                  + "replaces the value of the field for the given GUID. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "replaces the value of the field for the given GUID. "
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // Optional values
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
@@ -476,15 +476,15 @@ public enum CommandType {
   ReplaceOrCreateList(211, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceOrCreateList",
           CommandResultType.NULL, true, false,
           "Adds a field with the value to the GNS for the given guid if it does not exist otherwise "
-                  + "replaces the value of this field for the given guid with the value. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "replaces the value of this field for the given guid with the value. "
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
    *
@@ -492,12 +492,12 @@ public enum CommandType {
   ReplaceOrCreateListUnsigned(213, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceOrCreateListUnsigned",
           CommandResultType.NULL, true, false,
           "Adds a field to the GNS for the given guid if it does not exist otherwise "
-                  + "replaces the value of this field for the given guid with the value. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "replaces the value of this field for the given guid with the value. "
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()},
           new String[]{}),
   /**
    *
@@ -505,11 +505,11 @@ public enum CommandType {
   ReplaceOrCreateUnsigned(215, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceOrCreateUnsigned",
           CommandResultType.NULL, true, false,
           "Adds a field to the GNS for the given guid if it doesn not exist otherwise "
-                  + "replaces the value of this field for the given GUID. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "replaces the value of this field for the given GUID. "
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()},
           new String[]{}),
   /**
    *
@@ -517,10 +517,10 @@ public enum CommandType {
   ReplaceUnsigned(217, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceUnsigned",
           CommandResultType.NULL, true, false,
           "Replaces the current value field from the GNS for the given guid. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString()},
           new String[]{}),
   /**
    *
@@ -528,11 +528,11 @@ public enum CommandType {
   ReplaceUserJSON(220, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceUserJSON",
           CommandResultType.NULL, true, false,
           "Replaces existing fields in JSON record with the given JSONObject's fields. "
-                  + "Doesn't touch top-level fields that aren't in the given JSONObject.",
+          + "Doesn't touch top-level fields that aren't in the given JSONObject.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.USER_JSON.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.USER_JSON.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
    *
@@ -540,11 +540,11 @@ public enum CommandType {
   ReplaceUserJSONUnsigned(221, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.ReplaceUserJSONUnsigned",
           CommandResultType.NULL, true, false,
           "Replaces existing fields in JSON record with the given JSONObject's fields. "
-                  + "Field must be world writeable as this command does "
-                  + "not specify the writer and is not signed. Doesn't touch top-level "
-                  + "fields that aren't in the given JSONObject.",
+          + "Field must be world writeable as this command does "
+          + "not specify the writer and is not signed. Doesn't touch top-level "
+          + "fields that aren't in the given JSONObject.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.USER_JSON.toString()},
+            GNSProtocol.USER_JSON.toString()},
           new String[]{}),
   //Fixme: CREATE_INDEX should be an ADMIN_UPDATE command.
 
@@ -555,10 +555,10 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Creates an index for field. The value is a string containing the index type.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
    *
@@ -566,13 +566,13 @@ public enum CommandType {
   Substitute(231, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.Substitute",
           CommandResultType.NULL, true, false,
           "Replaces OLD_VALUE with newvalue in the field for the given GUID. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.OLD_VALUE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.OLD_VALUE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
    *
@@ -580,16 +580,16 @@ public enum CommandType {
   SubstituteList(232, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.SubstituteList",
           CommandResultType.NULL, true, false,
           "Replaces OLD_VALUE with newvalue in the field for the given GUID. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be writeable by the WRITER guid. "
-                  + "If the new value and old values list are different sizes this does the obvious things and "
-                  + "stops when it runs out of values on the shorter list.",
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be writeable by the WRITER guid. "
+          + "If the new value and old values list are different sizes this does the obvious things and "
+          + "stops when it runs out of values on the shorter list.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.OLD_VALUE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.OLD_VALUE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
    *
@@ -597,14 +597,14 @@ public enum CommandType {
   SubstituteListUnsigned(234, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.SubstituteListUnsigned",
           CommandResultType.NULL, true, false,
           "Replaces OLD_VALUE with newvalue in the field for the given GUID. "
-                  + "Value is a list of items formated as a JSON list. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed. "
-                  + "If the new value and old values list are different sizes this does the obvious things and "
-                  + "stops when it runs out of values on the shorter list.",
+          + "Value is a list of items formated as a JSON list. "
+          + "Field must be world writeable as this command does not specify the writer and is not signed. "
+          + "If the new value and old values list are different sizes this does the obvious things and "
+          + "stops when it runs out of values on the shorter list.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.OLD_VALUE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.OLD_VALUE.toString()},
           new String[]{}),
   /**
    *
@@ -612,11 +612,11 @@ public enum CommandType {
   SubstituteUnsigned(236, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.SubstituteUnsigned",
           CommandResultType.NULL, true, false,
           "Replaces OLD_VALUE with newvalue in the field for the given GUID. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.OLD_VALUE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.OLD_VALUE.toString()},
           new String[]{}),
   /**
    *
@@ -624,11 +624,11 @@ public enum CommandType {
   RemoveField(240, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.RemoveField",
           CommandResultType.NULL, true, false,
           "Removes the field from the GNS for the given guid after authenticating "
-                  + "that WRITER making request has access authority.",
+          + "that WRITER making request has access authority.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
    *
@@ -636,10 +636,10 @@ public enum CommandType {
   RemoveFieldUnsigned(242, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.RemoveFieldUnsigned",
           CommandResultType.NULL, true, false,
           "Removes the field from the GNS for the given guid. "
-                  + "Field must be world writeable as this command does not specify the writer and is not signed.",
+          + "Field must be world writeable as this command does not specify the writer and is not signed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.WRITER.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.WRITER.toString()},
           new String[]{}),
   /**
    *
@@ -647,13 +647,13 @@ public enum CommandType {
   Set(250, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.data.Set",
           CommandResultType.NULL, true, false,
           "Replaces element N with newvalue in the field for the given GUID. "
-                  + "Field must be writeable by the WRITER guid.",
+          + "Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString(),
-                  GNSProtocol.N.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.VALUE.toString(),
+            GNSProtocol.N.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
    *
@@ -662,9 +662,9 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Sets the field to contain a null value. Field must be writeable by the WRITER guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{GNSProtocol.WRITER.toString()}),
   //
   // Basic select commands
@@ -676,59 +676,60 @@ public enum CommandType {
   Select(310, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.Select",
           CommandResultType.LIST, false, false,
           "Returns the guids of all records that have a field with the given value. "
-                  + "Values are returned as a JSON array of guids. "
-                  + "This command is a shorthand for a mongo find query.",
+          + "Values are returned as a JSON array of guids. "
+          + "This command is a shorthand for a mongo find query.",
           new String[]{GNSProtocol.FIELD.toString(),
-                  GNSProtocol.VALUE.toString()},
+            GNSProtocol.VALUE.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   SelectNear(320, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.SelectNear",
           CommandResultType.LIST, false, false,
           "Return the guids of all records that are within max distance of value. Key must be a GeoSpatial field. "
-                  + "Value is a point specified as a JSONArray string tuple: [LONG, LAT]. Max Distance is in meters. "
-                  + "Values are returned as a JSON array of guids. "
-                  + "This command is a shorthand for a mongo $near query.",
+          + "Value is a point specified as a JSONArray string tuple: [LONG, LAT]. Max Distance is in meters. "
+          + "Values are returned as a JSON array of guids. "
+          + "This command is a shorthand for a mongo $near query.",
           new String[]{GNSProtocol.FIELD.toString(),
-                  GNSProtocol.NEAR.toString(),
-                  GNSProtocol.MAX_DISTANCE.toString()},
+            GNSProtocol.NEAR.toString(),
+            GNSProtocol.MAX_DISTANCE.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   SelectWithin(321, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.SelectWithin",
           CommandResultType.LIST, false, false,
           "Returns the guids of all records that are within value which is a bounding box specified. "
-                  + "Key must be a GeoSpatial field. "
-                  + "Bounding box is a nested JSONArray string tuple of paired tuples: [[LONG_BOTTOM_LEFT, LAT_BOTTOM_LEFT],[LONG_UPPER_RIGHT, LAT_UPPER_RIGHT]] "
-                  + "Values are returned as a JSON array of guids. "
-                  + "This command is a shorthand for a mongo $geoWithin query.",
+          + "Key must be a GeoSpatial field. "
+          + "Bounding box is a nested JSONArray string tuple of paired tuples: [[LONG_BOTTOM_LEFT, LAT_BOTTOM_LEFT],[LONG_UPPER_RIGHT, LAT_UPPER_RIGHT]] "
+          + "Values are returned as a JSON array of guids. "
+          + "This command is a shorthand for a mongo $geoWithin query.",
           new String[]{GNSProtocol.FIELD.toString(),
-                  GNSProtocol.WITHIN.toString()},
+            GNSProtocol.WITHIN.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   SelectQuery(322, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.SelectQuery",
           CommandResultType.LIST, false, false,
           "Returns the guids of all records that satisfy the query. "
-                  + "For details see http://gns.name/wiki/index.php/Query_Syntax "
-                  + "Values are returned as a JSON array of guids.",
+          + "For details see http://gns.name/wiki/index.php/Query_Syntax "
+          + "Values are returned as a JSON array of guids.",
           new String[]{GNSProtocol.QUERY.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.FIELDS.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   //
   // Select commands that maintain a group guid
   //
@@ -739,78 +740,78 @@ public enum CommandType {
   SelectGroupLookupQuery(311, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.SelectGroupLookupQuery",
           CommandResultType.LIST, false, false,
           "Prototype functionality of a full-fledged Context Name Service. "
-                  + "Returns all records for a group guid that was previously setup with SelectGroupSetupQuery. "
-                  + "For details see http://gns.name/wiki/index.php/Query_Syntax "
-                  + "Values are returned as a JSON array of guids.",
+          + "Returns all records for a group guid that was previously setup with SelectGroupSetupQuery. "
+          + "For details see http://gns.name/wiki/index.php/Query_Syntax "
+          + "Values are returned as a JSON array of guids.",
           new String[]{GNSProtocol.ACCOUNT_GUID.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   SelectGroupSetupQuery(312, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.SelectGroupSetupQuery",
           CommandResultType.LIST, false, false,
           "Prototype functionality of a full-fledged Context Name Service. "
-                  + "Initializes a new group guid to automatically update and maintain all records that satisfy the query. "
-                  + "For details see http://gns.name/wiki/index.php/Query_Syntax "
-                  + "Values are returned as a JSON array of guids.",
+          + "Initializes a new group guid to automatically update and maintain all records that satisfy the query. "
+          + "For details see http://gns.name/wiki/index.php/Query_Syntax "
+          + "Values are returned as a JSON array of guids.",
           new String[]{GNSProtocol.ACCOUNT_GUID.toString(),
-                  GNSProtocol.QUERY.toString()},
+            GNSProtocol.QUERY.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   SelectGroupSetupQueryWithGuid(313, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.SelectGroupSetupQueryWithGuid",
           CommandResultType.LIST, false, false,
           "Prototype functionality of a full-fledged Context Name Service. "
-                  + "Initializes the given group guid to automatically update and maintain all records that satisfy the query. "
-                  + "For details see http://gns.name/wiki/index.php/Query_Syntax "
-                  + "Values are returned as a JSON array of guids.",
+          + "Initializes the given group guid to automatically update and maintain all records that satisfy the query. "
+          + "For details see http://gns.name/wiki/index.php/Query_Syntax "
+          + "Values are returned as a JSON array of guids.",
           new String[]{GNSProtocol.QUERY.toString(),
-                  GNSProtocol.ACCOUNT_GUID.toString()},
+            GNSProtocol.ACCOUNT_GUID.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   SelectGroupSetupQueryWithGuidAndInterval(314, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.SelectGroupSetupQueryWithGuidAndInterval",
           CommandResultType.LIST, false, false,
           "Prototype functionality of a full-fledged Context Name Service. "
-                  + "Initializes the group guid to automatically update and maintain all records that satisfy the query. "
-                  + "Interval is the minimum refresh interval of the query - lookups happening more quickly than this "
-                  + "interval will retrieve a stale value.For details see http://gns.name/wiki/index.php/Query_Syntax"
-                  + "Values are returned as a JSON array of guids.",
+          + "Initializes the group guid to automatically update and maintain all records that satisfy the query. "
+          + "Interval is the minimum refresh interval of the query - lookups happening more quickly than this "
+          + "interval will retrieve a stale value.For details see http://gns.name/wiki/index.php/Query_Syntax"
+          + "Values are returned as a JSON array of guids.",
           new String[]{GNSProtocol.ACCOUNT_GUID.toString(),
-                  GNSProtocol.QUERY.toString(),
-                  GNSProtocol.INTERVAL.toString()},
+            GNSProtocol.QUERY.toString(),
+            GNSProtocol.INTERVAL.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   /**
    *
    */
   SelectGroupSetupQueryWithInterval(315, CommandCategory.SELECT, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.select.SelectGroupSetupQueryWithInterval",
           CommandResultType.LIST, false, false,
           "Prototype functionality of a full-fledged Context Name Service. "
-                  + "Initializes a new group guid to automatically update and maintain all records that satisfy the query. "
-                  + "Interval is the minimum refresh interval of the query - lookups happening more "
-                  + "quickly than this interval will retrieve a stale value. "
-                  + "For details see http://gns.name/wiki/index.php/Query_Syntax "
-                  + "Values are returned as a JSON array of guids.",
+          + "Initializes a new group guid to automatically update and maintain all records that satisfy the query. "
+          + "Interval is the minimum refresh interval of the query - lookups happening more "
+          + "quickly than this interval will retrieve a stale value. "
+          + "For details see http://gns.name/wiki/index.php/Query_Syntax "
+          + "Values are returned as a JSON array of guids.",
           new String[]{GNSProtocol.QUERY.toString(),
-                  GNSProtocol.INTERVAL.toString()},
+            GNSProtocol.INTERVAL.toString()},
           // optional parameters
           new String[]{GNSProtocol.GUID.toString(), // the reader
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}),
   //
   // Account commands
   //
@@ -821,11 +822,11 @@ public enum CommandType {
   AddAlias(410, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.AddAlias",
           CommandResultType.NULL, false, false,
           "Adds a additional human readble name to the account associated with the GUID. "
-                  + "Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
+          + "Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.NAME.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.NAME.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{}),
   /**
    *
@@ -833,12 +834,12 @@ public enum CommandType {
   AddGuid(411, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.AddGuid",
           CommandResultType.NULL, false, false,
           "Adds a guid to the account associated with the GUID. Must be signed by the guid. "
-                  + "Returns +BADGUID+ if the guid has not been registered.",
+          + "Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.NAME.toString(),
-                  GNSProtocol.GUID.toString(),
-                  GNSProtocol.PUBLIC_KEY.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.GUID.toString(),
+            GNSProtocol.PUBLIC_KEY.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{}),
   /**
    *
@@ -846,12 +847,12 @@ public enum CommandType {
   AddMultipleGuids(412, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.AddMultipleGuids",
           CommandResultType.NULL, false, false,
           "Creates multiple guids for the account associated with the account guid. "
-                  + "Must be signed by the account guid. Returns +BADGUID+ if the account guid has not been registered.",
+          + "Must be signed by the account guid. Returns +BADGUID+ if the account guid has not been registered.",
           new String[]{GNSProtocol.NAMES.toString(),
-                  GNSProtocol.GUID.toString(),
-                  GNSProtocol.PUBLIC_KEYS.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.GUID.toString(),
+            GNSProtocol.PUBLIC_KEYS.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{}),
   /**
    *
@@ -859,13 +860,13 @@ public enum CommandType {
   AddMultipleGuidsFast(413, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.AddMultipleGuidsFast",
           CommandResultType.NULL, false, false,
           "Creates multiple guids for the account associated with the account guid. "
-                  + "Must be signed by the account guid. The created guids can only be accessed "
-                  + "using the account guid because they have no private key info stored on the client. "
-                  + "Returns +BADGUID+ if the account guid has not been registered.",
+          + "Must be signed by the account guid. The created guids can only be accessed "
+          + "using the account guid because they have no private key info stored on the client. "
+          + "Returns +BADGUID+ if the account guid has not been registered.",
           new String[]{GNSProtocol.NAMES.toString(),
-                  GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.GUID.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{}),
   /**
    *
@@ -873,13 +874,13 @@ public enum CommandType {
   AddMultipleGuidsFastRandom(414, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.AddMultipleGuidsFastRandom",
           CommandResultType.NULL, false, false,
           "Creates multiple guids for the account associated with the account guid. "
-                  + "Must be signed by the account guid. The created guids can only be accessed using the "
-                  + "account guid because the have no private key info stored on the client."
-                  + "Returns +BADGUID+ if the account guid has not been registered.",
+          + "Must be signed by the account guid. The created guids can only be accessed using the "
+          + "account guid because the have no private key info stored on the client."
+          + "Returns +BADGUID+ if the account guid has not been registered.",
           new String[]{GNSProtocol.GUIDCNT.toString(),
-                  GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.GUID.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{}),
   /**
    *
@@ -887,7 +888,7 @@ public enum CommandType {
   LookupAccountRecord(420, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.LookupAccountRecord",
           CommandResultType.MAP, true, false,
           "Returns the account info associated with the given GUID. "
-                  + "Returns +BADGUID+ if the guid has not been registered.",
+          + "Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString()},
           new String[]{}),
   /**
@@ -896,9 +897,9 @@ public enum CommandType {
   LookupRandomGuids(421, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.LookupRandomGuids",
           CommandResultType.LIST, true, false,
           "Returns some number of random subguids from and account guid. Only for testing purposes. "
-                  + "Returns +BADGUID+ if the guid has not been registered.",
+          + "Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.GUIDCNT.toString()},
+            GNSProtocol.GUIDCNT.toString()},
           new String[]{}),
   /**
    *
@@ -906,7 +907,7 @@ public enum CommandType {
   LookupGuid(422, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.LookupGuid",
           CommandResultType.STRING, true, false,
           "Returns the guid associated with the name which is the human readable name (alias). "
-                  + "Returns +BADACCOUNT+ if the name has not been registered.",
+          + "Returns +BADACCOUNT+ if the name has not been registered.",
           new String[]{GNSProtocol.NAME.toString()},
           new String[]{}),
   /**
@@ -923,7 +924,7 @@ public enum CommandType {
   LookupGuidRecord(424, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.LookupGuidRecord",
           CommandResultType.MAP, true, false,
           "Returns human readable name and public key associated with the given GUID. "
-                  + "Returns +BADGUID+ if the guid has not been registered.",
+          + "Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString()},
           new String[]{}),
   /**
@@ -933,12 +934,12 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.RegisterAccount",
           CommandResultType.NULL, false, false,
           "Creates an account guid associated with the human readable name and the supplied public key. "
-                  + "Must be signed with the public key. Returns a guid.",
+          + "Must be signed with the public key. Returns a guid.",
           new String[]{GNSProtocol.NAME.toString(),
-                  GNSProtocol.PUBLIC_KEY.toString(),
-                  GNSProtocol.PASSWORD.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.PUBLIC_KEY.toString(),
+            GNSProtocol.PASSWORD.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{}),
   /**
    *
@@ -947,14 +948,14 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.secured.RegisterAccountSecured",
           CommandResultType.NULL, false, false,
           "Creates an account guid associated with the human readable name and the supplied public key. "
-                  + "Returns a guid. "
-                  + "Sent on the mutual auth channel. "
-                  + "Can only be sent from a client that has the correct ssl keys.",
+          + "Returns a guid. "
+          + "Sent on the mutual auth channel. "
+          + "Can only be sent from a client that has the correct ssl keys.",
           new String[]{GNSProtocol.NAME.toString(),
-                  GNSProtocol.PUBLIC_KEY.toString(),
-                  GNSProtocol.PASSWORD.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.PUBLIC_KEY.toString(),
+            GNSProtocol.PASSWORD.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{},
           CommandFlag.MUTUAL_AUTH // This is important - without this the command isn't secure.
   ),
@@ -964,35 +965,35 @@ public enum CommandType {
   RemoveAccount(440, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.RemoveAccount",
           CommandResultType.NULL, false, false,
           "Removes the account guid associated with the human readable name. "
-                  + "Must be signed by the guid.",
+          + "Must be signed by the guid.",
           new String[]{GNSProtocol.NAME.toString(),
-                  GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.GUID.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   RemoveAlias(441, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.RemoveAlias",
           CommandResultType.NULL, false, false,
           "Removes the alias from the account associated with the GUID. "
-                  + "Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
+          + "Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.NAME.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.NAME.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   RemoveGuid(442, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.RemoveGuid",
           CommandResultType.NULL, false, false,
           "Removes the guid from the account associated with the ACCOUNT_GUID. "
-                  + "Must be signed by the account guid or the guid if account guid is not provided. "
-                  + "Returns +BADGUID+ if the guid has not been registered.",
+          + "Must be signed by the account guid or the guid if account guid is not provided. "
+          + "Returns +BADGUID+ if the guid has not been registered.",
           new String[]{
-                  GNSProtocol.ACCOUNT_GUID.toString(),
-                  GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.ACCOUNT_GUID.toString(),
+            GNSProtocol.GUID.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1000,18 +1001,18 @@ public enum CommandType {
           CommandResultType.NULL, false, false,
           "Removes the GUID. Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
   RetrieveAliases(444, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.account.RetrieveAliases",
           CommandResultType.LIST, true, false,
           "Retrieves all aliases for the account associated with the GUID. "
-                  + "Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
+          + "Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1025,8 +1026,8 @@ public enum CommandType {
   RemoveAccountSecured(446, CommandCategory.CREATE_DELETE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.secured.RemoveAccountSecured",
           CommandResultType.NULL, false, false,
           "Removes the account guid associated with the human readable name."
-                  + "Sent on the mutual auth channel. "
-                  + "Can only be sent from a client that has the correct ssl keys.",
+          + "Sent on the mutual auth channel. "
+          + "Can only be sent from a client that has the correct ssl keys.",
           new String[]{GNSProtocol.NAME.toString()},
           new String[]{},
           CommandFlag.MUTUAL_AUTH // This is important - without this the command isn't secure.
@@ -1038,9 +1039,9 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Sets the password. Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.PASSWORD.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.PASSWORD.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1048,7 +1049,7 @@ public enum CommandType {
           CommandResultType.STRING, true, false,
           "Handles the completion of the verification process for a guid by supplying the correct code.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.CODE.toString()}, new String[]{}),
+            GNSProtocol.CODE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1056,8 +1057,8 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Resends the verification code email to the user. Must be signed by the guid. Returns +BADGUID+ if the guid has not been registered.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1065,8 +1066,8 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Resets the publickey for the account guid.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.PUBLIC_KEY.toString(),
-                  GNSProtocol.PASSWORD.toString()}, new String[]{}),
+            GNSProtocol.PUBLIC_KEY.toString(),
+            GNSProtocol.PASSWORD.toString()}, new String[]{}),
   //
   // ACL Commands
   //
@@ -1077,14 +1078,14 @@ public enum CommandType {
   AclAdd(510, CommandCategory.UPDATE, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.acl.AclAdd",
           CommandResultType.NULL, true, false,
           "Updates the access control list of the given GUID's field to include the accesser guid. Accessor guid can "
-                  + "be guid or group guid or +ALL+ which means anyone. "
-                  + "Field can be also be +ALL+ which means all fields can be read by the accessor. ",
+          + "be guid or group guid or +ALL+ which means anyone. "
+          + "Field can be also be +ALL+ which means all fields can be read by the accessor. ",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACCESSER.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACCESSER.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
@@ -1094,14 +1095,14 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.secured.AclAddSecured",
           CommandResultType.NULL, true, false,
           "Updates the access control list of the given GUID's field to include the accesser guid. Accessor guid can "
-                  + "be guid or group guid or +ALL+ which means anyone. "
-                  + "Field can be also be +ALL+ which means all fields can be read by the accessor. "
-                  + "Sent on the mutual auth channel. "
-                  + "Can only be sent from a client that has the correct ssl keys.",
+          + "be guid or group guid or +ALL+ which means anyone. "
+          + "Field can be also be +ALL+ which means all fields can be read by the accessor. "
+          + "Sent on the mutual auth channel. "
+          + "Can only be sent from a client that has the correct ssl keys.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACCESSER.toString(),
-                  GNSProtocol.ACL_TYPE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACCESSER.toString(),
+            GNSProtocol.ACL_TYPE.toString()},
           new String[]{},
           CommandFlag.MUTUAL_AUTH // This is important - without this the command isn't secure.
   ),
@@ -1112,14 +1113,14 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.acl.AclAddSelf",
           CommandResultType.NULL, true, false,
           "Updates the access control list of the given GUID's field to include the accesser guid. "
-                  + "Accessor should a guid or group guid or +ALL+ which means anyone. "
-                  + "Field can be also be +ALL+ which means all fields can be read by the accessor. ",
+          + "Accessor should a guid or group guid or +ALL+ which means anyone. "
+          + "Field can be also be +ALL+ which means all fields can be read by the accessor. ",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACCESSER.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACCESSER.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1127,13 +1128,13 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.acl.AclRemove",
           CommandResultType.NULL, true, false,
           "Updates the access control list of the given GUID's field to remove the accesser guid. "
-                  + "Accessor should be the guid or group guid to be removed.",
+          + "Accessor should be the guid or group guid to be removed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACCESSER.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACCESSER.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
@@ -1143,13 +1144,13 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.secured.AclRemoveSecured",
           CommandResultType.NULL, true, false,
           "Updates the access control list of the given GUID's field to remove the accesser guid. "
-                  + "Accessor should be the guid or group guid to be removed. "
-                  + "Sent on the mutual auth channel. "
-                  + "Can only be sent from a client that has the correct ssl keys.",
+          + "Accessor should be the guid or group guid to be removed. "
+          + "Sent on the mutual auth channel. "
+          + "Can only be sent from a client that has the correct ssl keys.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACCESSER.toString(),
-                  GNSProtocol.ACL_TYPE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACCESSER.toString(),
+            GNSProtocol.ACL_TYPE.toString()},
           new String[]{},
           CommandFlag.MUTUAL_AUTH // This is important - without this the command isn't secure.
   ),
@@ -1160,13 +1161,13 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.acl.AclRemoveSelf",
           CommandResultType.NULL, true, false,
           "Updates the access control list of the given GUID's field to remove the accesser guid. "
-                  + "Accessor should be the guid or group guid to be removed.",
+          + "Accessor should be the guid or group guid to be removed.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACCESSER.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACCESSER.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           new String[]{}),
   /**
    *
@@ -1176,10 +1177,10 @@ public enum CommandType {
           CommandResultType.LIST, true, false,
           "Returns the access control list for a guids's field.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.READER.toString()}),
   /**
@@ -1189,11 +1190,11 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.secured.AclRetrieveSecured",
           CommandResultType.LIST, true, false,
           "Returns the access control list for a guids's field. "
-                  + "Sent on the mutual auth channel. "
-                  + "Can only be sent from a client that has the correct ssl keys.",
+          + "Sent on the mutual auth channel. "
+          + "Can only be sent from a client that has the correct ssl keys.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACL_TYPE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACL_TYPE.toString()},
           new String[]{},
           CommandFlag.MUTUAL_AUTH // This is important - without this the command isn't secure.
   ),
@@ -1205,10 +1206,10 @@ public enum CommandType {
           CommandResultType.LIST, true, false,
           "Returns the access control list for a guids's field.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1217,10 +1218,10 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Creates an empty ACL.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
@@ -1231,10 +1232,10 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Deletes an ACL.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   /**
@@ -1245,10 +1246,10 @@ public enum CommandType {
           CommandResultType.BOOLEAN, true, false,
           "Returns \"true\" if the ACL exists \"false\" otherwise.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.FIELD.toString(),
-                  GNSProtocol.ACL_TYPE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.FIELD.toString(),
+            GNSProtocol.ACL_TYPE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // Optional paramaters
           new String[]{GNSProtocol.READER.toString()}),
   //
@@ -1262,11 +1263,11 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.group.AddMembersToGroup",
           CommandResultType.NULL, false, false,
           "Adds the member guids to the group specified by guid. "
-                  + "Writer guid needs to have write access and sign the command.",
+          + "Writer guid needs to have write access and sign the command.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.MEMBERS.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.MEMBERS.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   //  /**
@@ -1288,11 +1289,11 @@ public enum CommandType {
           "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.group.AddToGroup",
           CommandResultType.NULL, false, false,
           "Adds the member guid to the group specified by guid. "
-                  + "Writer guid needs to have write access and sign the command.",
+          + "Writer guid needs to have write access and sign the command.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.MEMBER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.MEMBER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   //  /**
@@ -1312,10 +1313,10 @@ public enum CommandType {
   GetGroupMembers(614, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.group.GetGroupMembers",
           CommandResultType.LIST, true, false,
           "Returns the members of the group formatted as a JSON Array. "
-                  + "Reader guid needs to have read access and sign the command.",
+          + "Reader guid needs to have read access and sign the command.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.READER.toString()}),
   //  /**
@@ -1333,10 +1334,10 @@ public enum CommandType {
   GetGroups(616, CommandCategory.READ, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.group.GetGroups",
           CommandResultType.LIST, true, false,
           "Returns the groups that a guid is a member of formatted as a JSON Array. "
-                  + "Reader guid needs to have read access and sign the command.",
+          + "Reader guid needs to have read access and sign the command.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.READER.toString()}),
   //  /**
@@ -1354,11 +1355,11 @@ public enum CommandType {
   RemoveFromGroup(620, CommandCategory.OTHER, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.group.RemoveFromGroup",
           CommandResultType.NULL, false, false,
           "Removes the member guid from the group specified by guid. "
-                  + "Writer guid needs to have write access and sign the command.",
+          + "Writer guid needs to have write access and sign the command.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.MEMBER.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.MEMBER.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   //  /**
@@ -1377,11 +1378,11 @@ public enum CommandType {
   RemoveMembersFromGroup(622, CommandCategory.OTHER, "edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.group.RemoveMembersFromGroup",
           CommandResultType.NULL, false, false,
           "Removes the member guids from the group specified by guid. "
-                  + "Writer guid needs to have write access and sign the command.",
+          + "Writer guid needs to have write access and sign the command.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.MEMBERS.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
+            GNSProtocol.MEMBERS.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()},
           // optional parameters
           new String[]{GNSProtocol.WRITER.toString()}),
   //  /**
@@ -1445,11 +1446,11 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Sets the given active code for the specified guid and action, ensuring the writer has permission.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.AC_ACTION.toString(),
-                  GNSProtocol.AC_CODE.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.AC_ACTION.toString(),
+            GNSProtocol.AC_CODE.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1457,10 +1458,10 @@ public enum CommandType {
           CommandResultType.NULL, true, false,
           "Clears the active code for the specified guid and action, ensuring the writer has permission.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.WRITER.toString(),
-                  GNSProtocol.AC_ACTION.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.WRITER.toString(),
+            GNSProtocol.AC_ACTION.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1469,10 +1470,10 @@ public enum CommandType {
           CommandResultType.STRING, true, false,
           "Returns the active code for the specified action, ensuring the reader has permission.",
           new String[]{GNSProtocol.GUID.toString(),
-                  GNSProtocol.READER.toString(),
-                  GNSProtocol.AC_ACTION.toString(),
-                  GNSProtocol.SIGNATURE.toString(),
-                  GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
+            GNSProtocol.READER.toString(),
+            GNSProtocol.AC_ACTION.toString(),
+            GNSProtocol.SIGNATURE.toString(),
+            GNSProtocol.SIGNATUREFULLMESSAGE.toString()}, new String[]{}),
   /**
    *
    */
@@ -1563,10 +1564,10 @@ public enum CommandType {
   }
 
   private CommandType(int number, CommandCategory category, String commandClass,
-                      CommandResultType returnType, boolean canBeSafelyCoordinated,
-                      boolean notForRogueClients, String description,
-                      String[] requiredParameters, String[] optionalParameters,
-                      CommandFlag... flags) {
+          CommandResultType returnType, boolean canBeSafelyCoordinated,
+          boolean notForRogueClients, String description,
+          String[] requiredParameters, String[] optionalParameters,
+          CommandFlag... flags) {
     this.number = number;
     this.category = category;
 
@@ -1606,7 +1607,7 @@ public enum CommandType {
       if (map.containsKey(type.getInt())) {
         GNSConfig.getLogger().warning(
                 "**** Duplicate number for command type " + type + ": "
-                        + type.getInt());
+                + type.getInt());
       }
       map.put(type.getInt(), type);
       lowerCaseCommandNameMapForHttp.put(type.name().toLowerCase(), type);

--- a/src/edu/umass/cs/gnsserver/database/CassandraRecords.java
+++ b/src/edu/umass/cs/gnsserver/database/CassandraRecords.java
@@ -346,7 +346,8 @@ public class CassandraRecords implements NoSQLRecords {
   }
 
   @Override
-  public AbstractRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField, String query) {
+  public AbstractRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField, 
+          String query, List<String> projection) {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 

--- a/src/edu/umass/cs/gnsserver/database/DiskMapRecords.java
+++ b/src/edu/umass/cs/gnsserver/database/DiskMapRecords.java
@@ -21,6 +21,7 @@ import edu.umass.cs.utils.DiskMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -380,9 +381,11 @@ public class DiskMapRecords implements NoSQLRecords {
   }
 
   @Override
-  public AbstractRecordCursor selectRecordsQuery(String collection, ColumnField valuesMapField, String query) throws FailedDBOperationException {
+  public AbstractRecordCursor selectRecordsQuery(String collection, ColumnField valuesMapField, 
+          String query, List<String> projection) throws FailedDBOperationException {
     getMap(collection).commit();
-    return getMongoRecords(collection).selectRecordsQuery(MongoRecords.DBNAMERECORD, valuesMapField, query);
+    return getMongoRecords(collection).selectRecordsQuery(MongoRecords.DBNAMERECORD, valuesMapField, 
+            query, projection);
   }
 
   @Override

--- a/src/edu/umass/cs/gnsserver/database/MongoRecords.java
+++ b/src/edu/umass/cs/gnsserver/database/MongoRecords.java
@@ -65,16 +65,16 @@ import java.util.logging.Level;
  * @author westy, Abhigyan, arun
  */
 public class MongoRecords implements NoSQLRecords {
-  
+
   private static final String DBROOTNAME = "UMASS_GNS_DB_";
   /**
    * The name of the document where name records are stored.
    */
   public static final String DBNAMERECORD = "NameRecord";
-  
+
   private DB db;
   private String dbName;
-  
+
   private MongoClient mongoClient;
   private MongoCollectionSpecs mongoCollectionSpecs;
 
@@ -96,7 +96,7 @@ public class MongoRecords implements NoSQLRecords {
   public MongoRecords(String nodeID, int port) {
     init(nodeID, port);
   }
-  
+
   private void init(String nodeID, int mongoPort) {
     if (Config.getGlobalBoolean(GNSConfig.GNSC.IN_MEMORY_DB)) {
       return;
@@ -111,7 +111,7 @@ public class MongoRecords implements NoSQLRecords {
             .addOtherIndex(new BasicDBObject(NameRecord.VALUES_MAP.getName() + "." + GNSProtocol.LOCATION_FIELD_NAME_2D_SPHERE.toString(), "2dsphere"));
     mongoCollectionSpecs.getCollectionSpec(DBNAMERECORD)
             .addOtherIndex(new BasicDBObject(NameRecord.VALUES_MAP.getName() + "." + GNSProtocol.IPADDRESS_FIELD_NAME.toString(), 1));
-    
+
     boolean fatalException = false;
     try {
       // use a unique name in case we have more than one on a machine (need to remove periods, btw)
@@ -125,7 +125,7 @@ public class MongoRecords implements NoSQLRecords {
         mongoClient = new MongoClient("localhost");
       }
       db = mongoClient.getDB(dbName);
-      
+
       initializeIndexes();
     } catch (UnknownHostException e) {
       fatalException = true;
@@ -139,13 +139,13 @@ public class MongoRecords implements NoSQLRecords {
       }
     }
   }
-  
+
   private void initializeIndexes() {
     for (MongoCollectionSpec spec : mongoCollectionSpecs.allCollectionSpecs()) {
       initializeIndex(spec.getName());
     }
   }
-  
+
   private void initializeIndex(String collectionName) {
     MongoCollectionSpec spec = mongoCollectionSpecs.getCollectionSpec(collectionName);
     db.getCollection(spec.getName()).createIndex(spec.getPrimaryIndex(), new BasicDBObject("unique", true));
@@ -154,7 +154,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     DatabaseConfig.getLogger().fine("Indexes initialized");
   }
-  
+
   @Override
   public void createIndex(String collectionName, String field, String index) {
     MongoCollectionSpec spec = mongoCollectionSpecs.getCollectionSpec(collectionName);
@@ -162,13 +162,13 @@ public class MongoRecords implements NoSQLRecords {
     DBObject index2d = BasicDBObjectBuilder.start(NameRecord.VALUES_MAP.getName() + "." + field, index).get();
     db.getCollection(spec.getName()).createIndex(index2d);
   }
-  
+
   @Override
   public void insert(String collectionName, String guid, JSONObject value) throws FailedDBOperationException, RecordExistsException {
     db.requestStart();
     try {
       db.requestEnsureConnection();
-      
+
       DBCollection collection = db.getCollection(collectionName);
       DBObject dbObject = (DBObject) JSON.parse(value.toString());
       try {
@@ -183,12 +183,12 @@ public class MongoRecords implements NoSQLRecords {
       db.requestDone();
     }
   }
-  
+
   @Override
   public JSONObject lookupEntireRecord(String collectionName, String guid) throws RecordNotFoundException, FailedDBOperationException {
     return lookupEntireRecord(collectionName, guid, false);
   }
-  
+
   private JSONObject lookupEntireRecord(String collectionName, String guid, boolean explain) throws RecordNotFoundException, FailedDBOperationException {
     long startTime = System.currentTimeMillis();
     db.requestStart();
@@ -230,7 +230,7 @@ public class MongoRecords implements NoSQLRecords {
       db.requestDone();
     }
   }
-  
+
   @Override
   public HashMap<ColumnField, Object> lookupSomeFields(String collectionName,
           String guid, ColumnField nameField, ColumnField valuesMapField, ArrayList<ColumnField> valuesMapKeys)
@@ -243,11 +243,11 @@ public class MongoRecords implements NoSQLRecords {
     try {
       String primaryKey = mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey().getName();
       db.requestEnsureConnection();
-      
+
       DBCollection collection = db.getCollection(collectionName);
       BasicDBObject query = new BasicDBObject(primaryKey, guid);
       BasicDBObject projection = new BasicDBObject().append("_id", 0);
-      
+
       if (valuesMapField != null && valuesMapKeys != null) {
         for (int i = 0; i < valuesMapKeys.size(); i++) {
           String fieldName = valuesMapField.getName() + "." + valuesMapKeys.get(i).getName();
@@ -273,7 +273,7 @@ public class MongoRecords implements NoSQLRecords {
           if (containsFieldDotNotation(userKey, bson) == false) {
             DatabaseConfig.getLogger().log(Level.FINE,
                     "DBObject doesn't contain {0}", new Object[]{userKey});
-            
+
             continue;
           }
           try {
@@ -309,7 +309,7 @@ public class MongoRecords implements NoSQLRecords {
       db.requestDone();
     }
   }
-  
+
   private Object getWithDotNotation(String key, BasicDBObject bson) throws JSONException {
     if (key.contains(".")) {
       int indexOfDot = key.indexOf(".");
@@ -328,7 +328,7 @@ public class MongoRecords implements NoSQLRecords {
       return result;
     }
   }
-  
+
   private boolean containsFieldDotNotation(String key, BasicDBObject bson) {
     try {
       return getWithDotNotation(key, bson) != null;
@@ -336,7 +336,7 @@ public class MongoRecords implements NoSQLRecords {
       return false;
     }
   }
-  
+
   @Override
   public boolean contains(String collectionName, String guid) throws FailedDBOperationException {
     db.requestStart();
@@ -354,7 +354,7 @@ public class MongoRecords implements NoSQLRecords {
       db.requestDone();
     }
   }
-  
+
   @Override
   public void removeEntireRecord(String collectionName, String guid) throws FailedDBOperationException {
     String primaryKey = mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey().getName();
@@ -367,7 +367,7 @@ public class MongoRecords implements NoSQLRecords {
               "Original mongo exception:" + e.getMessage());
     }
   }
-  
+
   @Override
   public void updateEntireRecord(String collectionName, String guid, ValuesMap valuesMap)
           throws FailedDBOperationException {
@@ -403,7 +403,7 @@ public class MongoRecords implements NoSQLRecords {
     // Maybe check the result?
     BulkWriteResult result = unordered.execute();
   }
-  
+
   @Override
   public void updateIndividualFields(String collectionName, String guid,
           ColumnField valuesMapField, ArrayList<ColumnField> valuesMapKeys,
@@ -430,7 +430,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     doUpdate(collectionName, guid, updates);
   }
-  
+
   private void doUpdate(String collectionName, String guid, BasicDBObject updates)
           throws FailedDBOperationException {
     String primaryKey = mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey().getName();
@@ -462,16 +462,16 @@ public class MongoRecords implements NoSQLRecords {
       return JSON.parse(object.toString());
     }
   }
-  
+
   @Override
   public void removeMapKeys(String collectionName, String name, ColumnField mapField, ArrayList<ColumnField> mapKeys)
           throws FailedDBOperationException {
     String primaryKey = mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey().getName();
     DBCollection collection = db.getCollection(collectionName);
     BasicDBObject query = new BasicDBObject(primaryKey, name);
-    
+
     BasicDBObject updates = new BasicDBObject();
-    
+
     if (mapField != null && mapKeys != null) {
       for (int i = 0; i < mapKeys.size(); i++) {
         String fieldName = mapField.getName() + "." + mapKeys.get(i).getName();
@@ -506,7 +506,7 @@ public class MongoRecords implements NoSQLRecords {
           throws FailedDBOperationException {
     return selectRecords(collectionName, valuesMapField, key, value, false);
   }
-  
+
   private MongoRecordCursor selectRecords(String collectionName, ColumnField valuesMapField, String key, Object value,
           boolean explain) throws FailedDBOperationException {
     db.requestEnsureConnection();
@@ -536,18 +536,18 @@ public class MongoRecords implements NoSQLRecords {
     }
     return new MongoRecordCursor(cursor, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-  
+
   @Override
   public MongoRecordCursor selectRecordsWithin(String collectionName, ColumnField valuesMapField, String key, String value)
           throws FailedDBOperationException {
     return selectRecordsWithin(collectionName, valuesMapField, key, value, false);
   }
-  
+
   private MongoRecordCursor selectRecordsWithin(String collectionName, ColumnField valuesMapField, String key, String value, boolean explain)
           throws FailedDBOperationException {
     db.requestEnsureConnection();
     DBCollection collection = db.getCollection(collectionName);
-    
+
     BasicDBList box = parseJSONArrayLocationStringIntoDBList(value);
     String fieldName = valuesMapField.getName() + "." + key;
     BasicDBObject shapeClause = new BasicDBObject("$box", box);
@@ -565,7 +565,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     return new MongoRecordCursor(cursor, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-  
+
   private BasicDBList parseJSONArrayLocationStringIntoDBList(String string) {
     BasicDBList box1 = new BasicDBList();
     BasicDBList box2 = new BasicDBList();
@@ -583,7 +583,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     return box;
   }
-  
+
   private final static double METERS_PER_DEGREE = 111.12 * 1000; // at the equator
 
   @Override
@@ -591,12 +591,12 @@ public class MongoRecords implements NoSQLRecords {
           Double maxDistance) throws FailedDBOperationException {
     return selectRecordsNear(collectionName, valuesMapField, key, value, maxDistance, false);
   }
-  
+
   private MongoRecordCursor selectRecordsNear(String collectionName, ColumnField valuesMapField, String key, String value,
           Double maxDistance, boolean explain) throws FailedDBOperationException {
     db.requestEnsureConnection();
     DBCollection collection = db.getCollection(collectionName);
-    
+
     double maxDistanceInRadians = maxDistance / METERS_PER_DEGREE;
     BasicDBList tuple = new BasicDBList();
     try {
@@ -621,20 +621,24 @@ public class MongoRecords implements NoSQLRecords {
     }
     return new MongoRecordCursor(cursor, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-  
+
   @Override
   public MongoRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField,
           String query, List<String> projection) throws FailedDBOperationException {
     return selectRecordsQuery(collectionName, valuesMapField, query, projection, false);
   }
-  
+
   private MongoRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField,
           String query, List<String> projection, boolean explain) throws FailedDBOperationException {
     db.requestEnsureConnection();
     DBCollection collection = db.getCollection(collectionName);
     DBCursor cursor = null;
     try {
-      if (projection == null) {
+      if (projection == null
+              // this handles the special case of the user wanting all fields 
+              // in the projection
+              || (!projection.isEmpty()
+              && projection.get(0).equals(GNSProtocol.ENTIRE_RECORD.toString()))) {
         cursor = collection.find(parseMongoQuery(query, valuesMapField));
       } else {
         cursor = collection.find(parseMongoQuery(query, valuesMapField), generateProjection(projection));
@@ -648,7 +652,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     return new MongoRecordCursor(cursor, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-  
+
   private DBObject parseMongoQuery(String query, ColumnField valuesMapField) {
     // convert something like this: ~fred : ($gt: 0) into the queryable 
     // format, namely this: {~nr_valuesMap.fred : ($gt: 0)}
@@ -664,7 +668,7 @@ public class MongoRecords implements NoSQLRecords {
     DBObject parse = (DBObject) JSON.parse(edittedQuery);
     return parse;
   }
-  
+
   public static String buildAndQuery(String... querys) {
     StringBuilder result = new StringBuilder();
     result.append("{$and: [");
@@ -677,7 +681,7 @@ public class MongoRecords implements NoSQLRecords {
     result.append("]}");
     return result.toString();
   }
-  
+
   private DBObject generateProjection(List<String> fields) {
     // produces { field1: true, field2: true ... }
     DBObject result = new BasicDBObject();
@@ -690,12 +694,12 @@ public class MongoRecords implements NoSQLRecords {
     }
     return result;
   }
-  
+
   @Override
   public MongoRecordCursor getAllRowsIterator(String collectionName) throws FailedDBOperationException {
     return new MongoRecordCursor(db, collectionName, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-  
+
   @Override
   public void printAllEntries(String collectionName) throws FailedDBOperationException {
     MongoRecordCursor cursor = getAllRowsIterator(collectionName);
@@ -703,7 +707,7 @@ public class MongoRecords implements NoSQLRecords {
       System.out.println(cursor.nextJSONObject());
     }
   }
-  
+
   @Override
   public String toString() {
     return "DB " + dbName;
@@ -733,19 +737,19 @@ public class MongoRecords implements NoSQLRecords {
     }
     String dbName = DBROOTNAME + sanitizeDBName(nodeID);
     mongoClient.dropDatabase(dbName);
-    
+
     List<String> names = mongoClient.getDatabaseNames();
     for (String name : names) {
       if (name.startsWith(dbName)) {
         mongoClient.dropDatabase(name);
       }
     }
-    
+
     System.out.println("Dropped DB " + dbName);
   }
-  
+
   private static String sanitizeDBName(String nodeID) {
     return nodeID.replace('.', '_');
   }
-  
+
 }

--- a/src/edu/umass/cs/gnsserver/database/MongoRecords.java
+++ b/src/edu/umass/cs/gnsserver/database/MongoRecords.java
@@ -623,11 +623,13 @@ public class MongoRecords implements NoSQLRecords {
   }
 
   @Override
-  public MongoRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField, String query) throws FailedDBOperationException {
-    return selectRecordsQuery(collectionName, valuesMapField, query, false);
+  public MongoRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField,
+          String query, List<String> projection) throws FailedDBOperationException {
+    return selectRecordsQuery(collectionName, valuesMapField, query, projection, false);
   }
 
-  private MongoRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField, String query, boolean explain) throws FailedDBOperationException {
+  private MongoRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField,
+          String query, List<String> projection, boolean explain) throws FailedDBOperationException {
     db.requestEnsureConnection();
     DBCollection collection = db.getCollection(collectionName);
     DBCursor cursor = null;
@@ -658,7 +660,7 @@ public class MongoRecords implements NoSQLRecords {
     DBObject parse = (DBObject) JSON.parse(edittedQuery);
     return parse;
   }
-  
+
   public static String buildAndQuery(String... querys) {
     StringBuilder result = new StringBuilder();
     result.append("{$and: [");

--- a/src/edu/umass/cs/gnsserver/database/MongoRecords.java
+++ b/src/edu/umass/cs/gnsserver/database/MongoRecords.java
@@ -687,8 +687,9 @@ public class MongoRecords implements NoSQLRecords {
     DBObject result = new BasicDBObject();
     // Always return the guid
     result.put(NameRecord.NAME.getName(), "true");
-    // This is the receiver knows it is a guid record
+    // Put this in so the upstream receiver knows that it is a GUID record
     result.put(NameRecord.VALUES_MAP.getName() + "." + AccountAccess.GUID_INFO, "true");
+    // Add all the fields in the projection
     for (String field : fields) {
       result.put(NameRecord.VALUES_MAP.getName() + "." + field, "true");
     }

--- a/src/edu/umass/cs/gnsserver/database/MongoRecords.java
+++ b/src/edu/umass/cs/gnsserver/database/MongoRecords.java
@@ -65,16 +65,16 @@ import java.util.logging.Level;
  * @author westy, Abhigyan, arun
  */
 public class MongoRecords implements NoSQLRecords {
-
+  
   private static final String DBROOTNAME = "UMASS_GNS_DB_";
   /**
    * The name of the document where name records are stored.
    */
   public static final String DBNAMERECORD = "NameRecord";
-
+  
   private DB db;
   private String dbName;
-
+  
   private MongoClient mongoClient;
   private MongoCollectionSpecs mongoCollectionSpecs;
 
@@ -96,7 +96,7 @@ public class MongoRecords implements NoSQLRecords {
   public MongoRecords(String nodeID, int port) {
     init(nodeID, port);
   }
-
+  
   private void init(String nodeID, int mongoPort) {
     if (Config.getGlobalBoolean(GNSConfig.GNSC.IN_MEMORY_DB)) {
       return;
@@ -111,7 +111,7 @@ public class MongoRecords implements NoSQLRecords {
             .addOtherIndex(new BasicDBObject(NameRecord.VALUES_MAP.getName() + "." + GNSProtocol.LOCATION_FIELD_NAME_2D_SPHERE.toString(), "2dsphere"));
     mongoCollectionSpecs.getCollectionSpec(DBNAMERECORD)
             .addOtherIndex(new BasicDBObject(NameRecord.VALUES_MAP.getName() + "." + GNSProtocol.IPADDRESS_FIELD_NAME.toString(), 1));
-
+    
     boolean fatalException = false;
     try {
       // use a unique name in case we have more than one on a machine (need to remove periods, btw)
@@ -125,7 +125,7 @@ public class MongoRecords implements NoSQLRecords {
         mongoClient = new MongoClient("localhost");
       }
       db = mongoClient.getDB(dbName);
-
+      
       initializeIndexes();
     } catch (UnknownHostException e) {
       fatalException = true;
@@ -139,13 +139,13 @@ public class MongoRecords implements NoSQLRecords {
       }
     }
   }
-
+  
   private void initializeIndexes() {
     for (MongoCollectionSpec spec : mongoCollectionSpecs.allCollectionSpecs()) {
       initializeIndex(spec.getName());
     }
   }
-
+  
   private void initializeIndex(String collectionName) {
     MongoCollectionSpec spec = mongoCollectionSpecs.getCollectionSpec(collectionName);
     db.getCollection(spec.getName()).createIndex(spec.getPrimaryIndex(), new BasicDBObject("unique", true));
@@ -154,7 +154,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     DatabaseConfig.getLogger().fine("Indexes initialized");
   }
-
+  
   @Override
   public void createIndex(String collectionName, String field, String index) {
     MongoCollectionSpec spec = mongoCollectionSpecs.getCollectionSpec(collectionName);
@@ -162,13 +162,13 @@ public class MongoRecords implements NoSQLRecords {
     DBObject index2d = BasicDBObjectBuilder.start(NameRecord.VALUES_MAP.getName() + "." + field, index).get();
     db.getCollection(spec.getName()).createIndex(index2d);
   }
-
+  
   @Override
   public void insert(String collectionName, String guid, JSONObject value) throws FailedDBOperationException, RecordExistsException {
     db.requestStart();
     try {
       db.requestEnsureConnection();
-
+      
       DBCollection collection = db.getCollection(collectionName);
       DBObject dbObject = (DBObject) JSON.parse(value.toString());
       try {
@@ -183,12 +183,12 @@ public class MongoRecords implements NoSQLRecords {
       db.requestDone();
     }
   }
-
+  
   @Override
   public JSONObject lookupEntireRecord(String collectionName, String guid) throws RecordNotFoundException, FailedDBOperationException {
     return lookupEntireRecord(collectionName, guid, false);
   }
-
+  
   private JSONObject lookupEntireRecord(String collectionName, String guid, boolean explain) throws RecordNotFoundException, FailedDBOperationException {
     long startTime = System.currentTimeMillis();
     db.requestStart();
@@ -230,7 +230,7 @@ public class MongoRecords implements NoSQLRecords {
       db.requestDone();
     }
   }
-
+  
   @Override
   public HashMap<ColumnField, Object> lookupSomeFields(String collectionName,
           String guid, ColumnField nameField, ColumnField valuesMapField, ArrayList<ColumnField> valuesMapKeys)
@@ -243,11 +243,11 @@ public class MongoRecords implements NoSQLRecords {
     try {
       String primaryKey = mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey().getName();
       db.requestEnsureConnection();
-
+      
       DBCollection collection = db.getCollection(collectionName);
       BasicDBObject query = new BasicDBObject(primaryKey, guid);
       BasicDBObject projection = new BasicDBObject().append("_id", 0);
-
+      
       if (valuesMapField != null && valuesMapKeys != null) {
         for (int i = 0; i < valuesMapKeys.size(); i++) {
           String fieldName = valuesMapField.getName() + "." + valuesMapKeys.get(i).getName();
@@ -273,7 +273,7 @@ public class MongoRecords implements NoSQLRecords {
           if (containsFieldDotNotation(userKey, bson) == false) {
             DatabaseConfig.getLogger().log(Level.FINE,
                     "DBObject doesn't contain {0}", new Object[]{userKey});
-
+            
             continue;
           }
           try {
@@ -309,7 +309,7 @@ public class MongoRecords implements NoSQLRecords {
       db.requestDone();
     }
   }
-
+  
   private Object getWithDotNotation(String key, BasicDBObject bson) throws JSONException {
     if (key.contains(".")) {
       int indexOfDot = key.indexOf(".");
@@ -328,7 +328,7 @@ public class MongoRecords implements NoSQLRecords {
       return result;
     }
   }
-
+  
   private boolean containsFieldDotNotation(String key, BasicDBObject bson) {
     try {
       return getWithDotNotation(key, bson) != null;
@@ -336,7 +336,7 @@ public class MongoRecords implements NoSQLRecords {
       return false;
     }
   }
-
+  
   @Override
   public boolean contains(String collectionName, String guid) throws FailedDBOperationException {
     db.requestStart();
@@ -354,7 +354,7 @@ public class MongoRecords implements NoSQLRecords {
       db.requestDone();
     }
   }
-
+  
   @Override
   public void removeEntireRecord(String collectionName, String guid) throws FailedDBOperationException {
     String primaryKey = mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey().getName();
@@ -367,7 +367,7 @@ public class MongoRecords implements NoSQLRecords {
               "Original mongo exception:" + e.getMessage());
     }
   }
-
+  
   @Override
   public void updateEntireRecord(String collectionName, String guid, ValuesMap valuesMap)
           throws FailedDBOperationException {
@@ -403,7 +403,7 @@ public class MongoRecords implements NoSQLRecords {
     // Maybe check the result?
     BulkWriteResult result = unordered.execute();
   }
-
+  
   @Override
   public void updateIndividualFields(String collectionName, String guid,
           ColumnField valuesMapField, ArrayList<ColumnField> valuesMapKeys,
@@ -430,7 +430,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     doUpdate(collectionName, guid, updates);
   }
-
+  
   private void doUpdate(String collectionName, String guid, BasicDBObject updates)
           throws FailedDBOperationException {
     String primaryKey = mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey().getName();
@@ -462,16 +462,16 @@ public class MongoRecords implements NoSQLRecords {
       return JSON.parse(object.toString());
     }
   }
-
+  
   @Override
   public void removeMapKeys(String collectionName, String name, ColumnField mapField, ArrayList<ColumnField> mapKeys)
           throws FailedDBOperationException {
     String primaryKey = mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey().getName();
     DBCollection collection = db.getCollection(collectionName);
     BasicDBObject query = new BasicDBObject(primaryKey, name);
-
+    
     BasicDBObject updates = new BasicDBObject();
-
+    
     if (mapField != null && mapKeys != null) {
       for (int i = 0; i < mapKeys.size(); i++) {
         String fieldName = mapField.getName() + "." + mapKeys.get(i).getName();
@@ -506,7 +506,7 @@ public class MongoRecords implements NoSQLRecords {
           throws FailedDBOperationException {
     return selectRecords(collectionName, valuesMapField, key, value, false);
   }
-
+  
   private MongoRecordCursor selectRecords(String collectionName, ColumnField valuesMapField, String key, Object value,
           boolean explain) throws FailedDBOperationException {
     db.requestEnsureConnection();
@@ -536,18 +536,18 @@ public class MongoRecords implements NoSQLRecords {
     }
     return new MongoRecordCursor(cursor, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-
+  
   @Override
   public MongoRecordCursor selectRecordsWithin(String collectionName, ColumnField valuesMapField, String key, String value)
           throws FailedDBOperationException {
     return selectRecordsWithin(collectionName, valuesMapField, key, value, false);
   }
-
+  
   private MongoRecordCursor selectRecordsWithin(String collectionName, ColumnField valuesMapField, String key, String value, boolean explain)
           throws FailedDBOperationException {
     db.requestEnsureConnection();
     DBCollection collection = db.getCollection(collectionName);
-
+    
     BasicDBList box = parseJSONArrayLocationStringIntoDBList(value);
     String fieldName = valuesMapField.getName() + "." + key;
     BasicDBObject shapeClause = new BasicDBObject("$box", box);
@@ -565,7 +565,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     return new MongoRecordCursor(cursor, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-
+  
   private BasicDBList parseJSONArrayLocationStringIntoDBList(String string) {
     BasicDBList box1 = new BasicDBList();
     BasicDBList box2 = new BasicDBList();
@@ -583,7 +583,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     return box;
   }
-
+  
   private final static double METERS_PER_DEGREE = 111.12 * 1000; // at the equator
 
   @Override
@@ -591,12 +591,12 @@ public class MongoRecords implements NoSQLRecords {
           Double maxDistance) throws FailedDBOperationException {
     return selectRecordsNear(collectionName, valuesMapField, key, value, maxDistance, false);
   }
-
+  
   private MongoRecordCursor selectRecordsNear(String collectionName, ColumnField valuesMapField, String key, String value,
           Double maxDistance, boolean explain) throws FailedDBOperationException {
     db.requestEnsureConnection();
     DBCollection collection = db.getCollection(collectionName);
-
+    
     double maxDistanceInRadians = maxDistance / METERS_PER_DEGREE;
     BasicDBList tuple = new BasicDBList();
     try {
@@ -621,20 +621,24 @@ public class MongoRecords implements NoSQLRecords {
     }
     return new MongoRecordCursor(cursor, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-
+  
   @Override
   public MongoRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField,
           String query, List<String> projection) throws FailedDBOperationException {
     return selectRecordsQuery(collectionName, valuesMapField, query, projection, false);
   }
-
+  
   private MongoRecordCursor selectRecordsQuery(String collectionName, ColumnField valuesMapField,
           String query, List<String> projection, boolean explain) throws FailedDBOperationException {
     db.requestEnsureConnection();
     DBCollection collection = db.getCollection(collectionName);
     DBCursor cursor = null;
     try {
-      cursor = collection.find(parseMongoQuery(query, valuesMapField));
+      if (projection == null) {
+        cursor = collection.find(parseMongoQuery(query, valuesMapField));
+      } else {
+        cursor = collection.find(parseMongoQuery(query, valuesMapField), generateProjection(projection));
+      }
     } catch (MongoException e) {
       throw new FailedDBOperationException(collectionName, query,
               "Original mongo exception:" + e.getMessage());
@@ -644,7 +648,7 @@ public class MongoRecords implements NoSQLRecords {
     }
     return new MongoRecordCursor(cursor, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-
+  
   private DBObject parseMongoQuery(String query, ColumnField valuesMapField) {
     // convert something like this: ~fred : ($gt: 0) into the queryable 
     // format, namely this: {~nr_valuesMap.fred : ($gt: 0)}
@@ -660,7 +664,7 @@ public class MongoRecords implements NoSQLRecords {
     DBObject parse = (DBObject) JSON.parse(edittedQuery);
     return parse;
   }
-
+  
   public static String buildAndQuery(String... querys) {
     StringBuilder result = new StringBuilder();
     result.append("{$and: [");
@@ -673,12 +677,25 @@ public class MongoRecords implements NoSQLRecords {
     result.append("]}");
     return result.toString();
   }
-
+  
+  private DBObject generateProjection(List<String> fields) {
+    // produces { field1: true, field2: true ... }
+    DBObject result = new BasicDBObject();
+    // Always return the guid
+    result.put(NameRecord.NAME.getName(), "true");
+    // This is the receiver knows it is a guid record
+    result.put(NameRecord.VALUES_MAP.getName() + "." + AccountAccess.GUID_INFO, "true");
+    for (String field : fields) {
+      result.put(NameRecord.VALUES_MAP.getName() + "." + field, "true");
+    }
+    return result;
+  }
+  
   @Override
   public MongoRecordCursor getAllRowsIterator(String collectionName) throws FailedDBOperationException {
     return new MongoRecordCursor(db, collectionName, mongoCollectionSpecs.getCollectionSpec(collectionName).getPrimaryKey());
   }
-
+  
   @Override
   public void printAllEntries(String collectionName) throws FailedDBOperationException {
     MongoRecordCursor cursor = getAllRowsIterator(collectionName);
@@ -686,7 +703,7 @@ public class MongoRecords implements NoSQLRecords {
       System.out.println(cursor.nextJSONObject());
     }
   }
-
+  
   @Override
   public String toString() {
     return "DB " + dbName;
@@ -716,19 +733,19 @@ public class MongoRecords implements NoSQLRecords {
     }
     String dbName = DBROOTNAME + sanitizeDBName(nodeID);
     mongoClient.dropDatabase(dbName);
-
+    
     List<String> names = mongoClient.getDatabaseNames();
     for (String name : names) {
       if (name.startsWith(dbName)) {
         mongoClient.dropDatabase(name);
       }
     }
-
+    
     System.out.println("Dropped DB " + dbName);
   }
-
+  
   private static String sanitizeDBName(String nodeID) {
     return nodeID.replace('.', '_');
   }
-
+  
 }

--- a/src/edu/umass/cs/gnsserver/database/NoSQLRecords.java
+++ b/src/edu/umass/cs/gnsserver/database/NoSQLRecords.java
@@ -26,6 +26,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Provides an interface for insert, update, remove and lookup 
@@ -204,10 +205,12 @@ public interface NoSQLRecords {
    * @param collection the name of the collection
    * @param valuesMapField the field that contains the ValuesMap
    * @param query the query to execute
+   * @param projection
    * @return an AbstractRecordCursor
    * @throws edu.umass.cs.gnscommon.exceptions.server.FailedDBOperationException
    */
-  public AbstractRecordCursor selectRecordsQuery(String collection, ColumnField valuesMapField, String query)
+  public AbstractRecordCursor selectRecordsQuery(String collection, ColumnField valuesMapField, 
+          String query, List<String> projection)
           throws edu.umass.cs.gnscommon.exceptions.server.FailedDBOperationException;
 
   /**

--- a/src/edu/umass/cs/gnsserver/gnsapp/NSSelectInfo.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/NSSelectInfo.java
@@ -45,6 +45,8 @@ public class NSSelectInfo {
   private final SelectGroupBehavior groupBehavior;
   private final String guid; // the group GUID we are maintaining or null for simple select
   private final String query; // The string used to set up the query if applicable
+  // The list of fields to return. 
+  // Null means return GUIDS instead of whole records (old style select).
   private final List<String> projection;
   private final int minRefreshInterval; // in seconds
 
@@ -170,7 +172,10 @@ public class NSSelectInfo {
   }
 
   /**
-   *
+   * Return the projection which is a list of fields.
+   * Null means that select should return a list of guids instead
+   * of records (old-style).
+   * 
    * @return the projection
    */
   public List<String> getProjection() {

--- a/src/edu/umass/cs/gnsserver/gnsapp/NSSelectInfo.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/NSSelectInfo.java
@@ -27,6 +27,7 @@ import org.json.JSONObject;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,6 +43,7 @@ public class NSSelectInfo {
   private final SelectGroupBehavior groupBehavior;
   private final String guid; // the group GUID we are maintaining or null for simple select
   private final String query; // The string used to set up the query if applicable
+  private final List<String> projection;
   private final int minRefreshInterval; // in seconds
   /**
    * 
@@ -50,10 +52,13 @@ public class NSSelectInfo {
    * @param selectOperation 
    * @param groupBehavior 
    * @param query 
+   * @param projection 
    * @param minRefreshInterval 
    * @param guid 
    */
-  public NSSelectInfo(int id, Set<InetSocketAddress> serverIds, SelectOperation selectOperation, SelectGroupBehavior groupBehavior, String query, int minRefreshInterval, String guid) {
+  public NSSelectInfo(int id, Set<InetSocketAddress> serverIds, 
+          SelectOperation selectOperation, SelectGroupBehavior groupBehavior, 
+          String query, List<String> projection, int minRefreshInterval, String guid) {
     this.queryId = id;
     this.serversToBeProcessed = Collections.newSetFromMap(new ConcurrentHashMap<InetSocketAddress, Boolean>());
     this.serversToBeProcessed.addAll(serverIds);
@@ -61,6 +66,7 @@ public class NSSelectInfo {
     this.selectOperation = selectOperation;
     this.groupBehavior = groupBehavior;
     this.query = query;
+    this.projection = projection;
     this.guid = guid;
     this.minRefreshInterval = minRefreshInterval;
   }
@@ -146,6 +152,14 @@ public class NSSelectInfo {
    */
   public String getQuery() {
     return query;
+  }
+
+  /**
+   * 
+   * @return the projection
+   */
+  public List<String> getProjection() {
+    return projection;
   }
   
   /**

--- a/src/edu/umass/cs/gnsserver/gnsapp/NSSelectInfo.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/NSSelectInfo.java
@@ -23,6 +23,7 @@ import edu.umass.cs.gnsserver.gnsapp.packet.SelectGroupBehavior;
 import edu.umass.cs.gnsserver.gnsapp.packet.SelectOperation;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import org.json.JSONObject;
 
 import java.util.Collections;
@@ -36,6 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * about Select operations performed on the GNS.
  */
 public class NSSelectInfo {
+
   private final int queryId;
   private final Set<InetSocketAddress> serversToBeProcessed; // the list of servers that have yet to be processed
   private final ConcurrentHashMap<String, JSONObject> responses;
@@ -45,19 +47,20 @@ public class NSSelectInfo {
   private final String query; // The string used to set up the query if applicable
   private final List<String> projection;
   private final int minRefreshInterval; // in seconds
+
   /**
-   * 
+   *
    * @param id
-   * @param serverIds 
-   * @param selectOperation 
-   * @param groupBehavior 
-   * @param query 
-   * @param projection 
-   * @param minRefreshInterval 
-   * @param guid 
+   * @param serverIds
+   * @param selectOperation
+   * @param groupBehavior
+   * @param query
+   * @param projection
+   * @param minRefreshInterval
+   * @param guid
    */
-  public NSSelectInfo(int id, Set<InetSocketAddress> serverIds, 
-          SelectOperation selectOperation, SelectGroupBehavior groupBehavior, 
+  public NSSelectInfo(int id, Set<InetSocketAddress> serverIds,
+          SelectOperation selectOperation, SelectGroupBehavior groupBehavior,
           String query, List<String> projection, int minRefreshInterval, String guid) {
     this.queryId = id;
     this.serversToBeProcessed = Collections.newSetFromMap(new ConcurrentHashMap<InetSocketAddress, Boolean>());
@@ -72,7 +75,7 @@ public class NSSelectInfo {
   }
 
   /**
-   * 
+   *
    * @return the queryId
    */
   public int getId() {
@@ -81,21 +84,24 @@ public class NSSelectInfo {
 
   /**
    * Removes the server if from the list of servers that have yet to be processed.
-   * @param address 
+   *
+   * @param address
    */
   public void removeServerAddress(InetSocketAddress address) {
     serversToBeProcessed.remove(address);
   }
+
   /**
-   * 
+   *
    * @return the set of servers
    */
   public Set<InetSocketAddress> serversYetToRespond() {
     return serversToBeProcessed;
   }
+
   /**
    * Returns true if all the names servers have responded.
-   * 
+   *
    * @return true if all the names servers have responded
    */
   public boolean allServersResponded() {
@@ -104,7 +110,7 @@ public class NSSelectInfo {
 
   /**
    * Adds the result of a query for a particular guid if the guid has not been seen yet.
-   * 
+   *
    * @param name
    * @param json
    * @return true if the response was not seen yet, false otherwise
@@ -120,7 +126,7 @@ public class NSSelectInfo {
 
   /**
    * Returns that responses that have been see for this query.
-   * 
+   *
    * @return a set of JSONObjects
    */
   public Set<JSONObject> getResponsesAsSet() {
@@ -128,8 +134,17 @@ public class NSSelectInfo {
   }
 
   /**
+   * Returns that responses that have been see for this query.
+   *
+   * @return a set of JSONObjects
+   */
+  public List<JSONObject> getResponsesAsList() {
+    return new ArrayList<>(responses.values());
+  }
+
+  /**
    * Return the operation.
-   * 
+   *
    * @return a {@link SelectOperation}
    */
   public SelectOperation getSelectOperation() {
@@ -138,16 +153,16 @@ public class NSSelectInfo {
 
   /**
    * Return the behavior.
-   * 
+   *
    * @return a GroupBehavior
    */
   public SelectGroupBehavior getGroupBehavior() {
     return groupBehavior;
   }
-  
+
   /**
    * Return the query.
-   * 
+   *
    * @return a string
    */
   public String getQuery() {
@@ -155,16 +170,16 @@ public class NSSelectInfo {
   }
 
   /**
-   * 
+   *
    * @return the projection
    */
   public List<String> getProjection() {
     return projection;
   }
-  
+
   /**
    * Return the guid.
-   * 
+   *
    * @return a string
    */
   public String getGuid() {
@@ -173,11 +188,11 @@ public class NSSelectInfo {
 
   /**
    * Return the minimum refresh interval.
-   * 
+   *
    * @return an int
    */
   public int getMinRefreshInterval() {
     return minRefreshInterval;
   }
-  
+
 }

--- a/src/edu/umass/cs/gnsserver/gnsapp/Select.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/Select.java
@@ -87,8 +87,8 @@ import java.util.regex.Pattern;
  * SelectQuery can be used two ways. The older style is that it returns a
  * list of GUIDS. The newer style is that it returns entire records or
  * subsets of the fields in records. The guid of the record is returned
- * in the using the special "_GUID" key.
- * The behavior SelectQuery of is controlled by the
+ * using the special "_GUID" key.
+ * The behavior of SelectQuery is controlled by the
  * field (or projection) parameter. In this code if it is null that means
  * old style.
  *
@@ -457,10 +457,11 @@ public class Select {
             new Object[]{replica.getNodeID(), guids});
 
     SelectResponsePacket response;
+    // If projection is null we return guids (old-style).
     if (info.getProjection() == null) {
-
       response = SelectResponsePacket.makeSuccessPacketForGuidsOnly(packet.getId(),
               null, -1, null, new JSONArray(guids));
+      // Otherwise we return a list of records.
     } else {
       List<JSONObject> records = filterAndMassageRecords(allRecords);
       LOGGER.log(Level.FINE,

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/FieldAccess.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/FieldAccess.java
@@ -728,6 +728,7 @@ public class FieldAccess {
    * @param commandPacket
    * @param reader
    * @param query
+   * @param projection
    * @param signature
    * @param message
    * @param handler
@@ -735,7 +736,7 @@ public class FieldAccess {
    * @throws InternalRequestException
    */
   public static CommandResponse selectQuery(InternalRequestHeader header, CommandPacket commandPacket,
-          String reader, String query,
+          String reader, String query, List<String> projection,
           String signature, String message,
           ClientRequestHandlerInterface handler) throws InternalRequestException {
     if (Select.queryContainsEvil(query)) {
@@ -746,7 +747,7 @@ public class FieldAccess {
     }
     JSONArray result;
     try {
-      SelectRequestPacket packet = SelectRequestPacket.MakeQueryRequest(-1, reader, query);
+      SelectRequestPacket packet = SelectRequestPacket.MakeQueryRequest(-1, reader, query, projection);
       result = executeSelectHelper(header, commandPacket, packet, reader, signature, message, handler.getApp());
       if (result != null) {
         return new CommandResponse(ResponseCode.NO_ERROR, result.toString());
@@ -817,7 +818,7 @@ public class FieldAccess {
 
     try {
       SelectRequestPacket packet = SelectRequestPacket.MakeGroupSetupRequest(-1,
-              reader, query, guid, interval);
+              reader, query, null, guid, interval);
       result = executeSelectHelper(header, commandPacket, packet, reader, signature, message, handler.getApp());
       if (result != null) {
         return new CommandResponse(ResponseCode.NO_ERROR, result.toString());

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/FieldAccess.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/FieldAccess.java
@@ -595,8 +595,11 @@ public class FieldAccess {
     if (responsePacket != null
             && // Fixme: probably should just have handleSelectRequestFromClient throw a clientException
             SelectResponsePacket.ResponseCode.NOERROR.equals(responsePacket.getResponseCode())) {
-      JSONArray guids = responsePacket.getGuids();
-      return guids;
+      if (packet.getProjection() == null) {
+        return responsePacket.getGuids();
+      } else {
+        return responsePacket.getRecords();
+      }
     } else {
       return null;
     }

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/select/SelectQuery.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/select/SelectQuery.java
@@ -30,6 +30,8 @@ import edu.umass.cs.gnscommon.exceptions.server.InternalRequestException;
 import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commands.AbstractCommand;
 import edu.umass.cs.gnsserver.interfaces.InternalRequestHeader;
 
+import edu.umass.cs.gnsserver.utils.JSONUtils;
+import java.util.ArrayList;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -62,9 +64,12 @@ public class SelectQuery extends AbstractCommand {
     JSONObject json = commandPacket.getCommand();
     String reader = json.optString(GNSProtocol.GUID.toString(), null);
     String query = json.getString(GNSProtocol.QUERY.toString());
+    ArrayList<String> fields = json.has(GNSProtocol.FIELDS.toString())
+            ? JSONUtils.JSONArrayToArrayListString(json.getJSONArray(GNSProtocol.FIELDS.toString())) : null;
     String signature = json.optString(GNSProtocol.SIGNATURE.toString(), null);
     String message = json.optString(GNSProtocol.SIGNATUREFULLMESSAGE.toString(), null);
-    return FieldAccess.selectQuery(header, commandPacket, reader, query, signature, message, handler);
+    return FieldAccess.selectQuery(header, commandPacket, reader, query, fields,
+            signature, message, handler);
   }
 
 }

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/select/SelectQuery.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/select/SelectQuery.java
@@ -38,6 +38,9 @@ import org.json.JSONObject;
 
 /**
  * A query that returns all guids that satisfy the given query.
+ * This supports an older style that returns only GUIDs 
+ * as well as newer SelectRecords calls that return entire records
+ * or partial records based on the value of the FIELDS parameter.
  *
  * @author westy
  */

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/select/SelectQuery.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/select/SelectQuery.java
@@ -32,6 +32,7 @@ import edu.umass.cs.gnsserver.interfaces.InternalRequestHeader;
 
 import edu.umass.cs.gnsserver.utils.JSONUtils;
 import java.util.ArrayList;
+import java.util.Arrays;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -64,10 +65,22 @@ public class SelectQuery extends AbstractCommand {
     JSONObject json = commandPacket.getCommand();
     String reader = json.optString(GNSProtocol.GUID.toString(), null);
     String query = json.getString(GNSProtocol.QUERY.toString());
-    ArrayList<String> fields = json.has(GNSProtocol.FIELDS.toString())
-            ? JSONUtils.JSONArrayToArrayListString(json.getJSONArray(GNSProtocol.FIELDS.toString())) : null;
+
     String signature = json.optString(GNSProtocol.SIGNATURE.toString(), null);
     String message = json.optString(GNSProtocol.SIGNATUREFULLMESSAGE.toString(), null);
+    // Special case handling of the fields argument
+    // Empty means this is an older style select which is converted to null
+    // GNSProtocol.ENTIRE_RECORD means what you think and is converted to a unique value which
+    // is the fields array is length one and has GNSProtocol.ENTIRE_RECORD string as the first element
+    // otherwise it is a list of fields
+    ArrayList<String> fields;
+    if (!json.has(GNSProtocol.FIELDS.toString())) {
+      fields = null;
+    } else if (GNSProtocol.ENTIRE_RECORD.toString().equals(json.optString(GNSProtocol.FIELDS.toString()))) {
+      fields = new ArrayList<>(Arrays.asList(GNSProtocol.ENTIRE_RECORD.toString()));
+    } else {
+      fields = JSONUtils.JSONArrayToArrayListString(json.getJSONArray(GNSProtocol.FIELDS.toString()));
+    }
     return FieldAccess.selectQuery(header, commandPacket, reader, query, fields,
             signature, message, handler);
   }

--- a/src/edu/umass/cs/gnsserver/gnsapp/packet/SelectResponsePacket.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/packet/SelectResponsePacket.java
@@ -97,7 +97,7 @@ public class SelectResponsePacket extends BasicPacketWithReturnAddressAndNsAddre
    * @param records
    * @return a SelectResponsePacket
    */
-  public static SelectResponsePacket makeSuccessPacketForRecordsOnly(
+  public static SelectResponsePacket makeSuccessPacketForFullRecords(
           long id, InetSocketAddress lnsAddress,
           long lnsQueryId,
           int nsQueryId, InetSocketAddress nsAddress, JSONArray records) {

--- a/src/edu/umass/cs/gnsserver/gnsapp/recordmap/GNSRecordMap.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/recordmap/GNSRecordMap.java
@@ -32,6 +32,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.logging.Level;
 
 /**
@@ -138,8 +139,9 @@ public class GNSRecordMap<NodeIDType> extends BasicRecordMap {
   }
 
   @Override
-  public AbstractRecordCursor selectRecordsQuery(ColumnField valuesMapField, String query) throws FailedDBOperationException {
-    return noSqlRecords.selectRecordsQuery(collectionName, valuesMapField, query);
+  public AbstractRecordCursor selectRecordsQuery(ColumnField valuesMapField, 
+          String query, List<String> projection) throws FailedDBOperationException {
+    return noSqlRecords.selectRecordsQuery(collectionName, valuesMapField, query, projection);
   }
 
   @Override

--- a/src/edu/umass/cs/gnsserver/gnsapp/recordmap/NameRecord.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/recordmap/NameRecord.java
@@ -37,6 +37,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.logging.Level;
 
 /**
@@ -470,11 +471,13 @@ public class NameRecord implements Comparable<NameRecord>, Summarizable {
    *
    * @param recordMap
    * @param query
+   * @param projection
    * @return an {@link AbstractRecordCursor}
    * @throws edu.umass.cs.gnscommon.exceptions.server.FailedDBOperationException
    */
-  public static AbstractRecordCursor selectRecordsQuery(BasicRecordMap recordMap, String query) throws FailedDBOperationException {
-    return recordMap.selectRecordsQuery(NameRecord.VALUES_MAP, query);
+  public static AbstractRecordCursor selectRecordsQuery(BasicRecordMap recordMap, 
+          String query, List<String> projection) throws FailedDBOperationException {
+    return recordMap.selectRecordsQuery(NameRecord.VALUES_MAP, query, projection);
   }
 
   /**

--- a/src/edu/umass/cs/gnsserver/gnsapp/recordmap/RecordMapInterface.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/recordmap/RecordMapInterface.java
@@ -29,6 +29,7 @@ import edu.umass.cs.gnsserver.utils.ValuesMap;
 import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  *
@@ -191,10 +192,11 @@ public interface RecordMapInterface {
    *
    * @param valuesMapField
    * @param query
+   * @param projection
    * @return {@link AbstractRecordCursor}
    * @throws FailedDBOperationException
    */
   public abstract AbstractRecordCursor selectRecordsQuery(ColumnField valuesMapField,
-          String query) throws FailedDBOperationException;
+          String query, List<String> projection) throws FailedDBOperationException;
 
 }

--- a/test/edu/umass/cs/gnsclient/client/integrationtests/ServerFailureTests.java
+++ b/test/edu/umass/cs/gnsclient/client/integrationtests/ServerFailureTests.java
@@ -34,6 +34,12 @@ import edu.umass.cs.gnscommon.utils.ThreadUtils;
 import edu.umass.cs.nio.JSONDelayEmulator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Brendan

--- a/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
@@ -166,20 +166,6 @@ public class SelectTest extends DefaultGNSTest {
     }
   }
 
-//  /**
-//   * Check the basic field select command with world readable records
-//   */
-//  @Test
-//  public void test_31_BasicSelectWorldReadable() {
-//    try {
-//      JSONArray result = clientCommands.select("cats", "fred");
-//      // best we can do since there will be one, but possibly more objects in results
-//      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(1));
-//    } catch (ClientException | IOException e) {
-//      Utils.failWithStackTrace("Exception when we were not expecting it: " + e);
-//    }
-//  }
-
   /**
    * Check a near and within commands
    */

--- a/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
@@ -147,6 +147,8 @@ public class SelectTest extends DefaultGNSTest {
       Utils.failWithStackTrace("Exception when we were not expecting testing DB: " + e);
     }
   }
+  
+  private static final int WAIT_SETTLE = 500;
 
   /**
    * Check the basic field select command
@@ -154,7 +156,7 @@ public class SelectTest extends DefaultGNSTest {
   @Test
   public void test_30_BasicSelect() {
     try {
-      waitSettle(100);
+      waitSettle(WAIT_SETTLE);
       JSONArray result = clientCommands.select(masterGuid, "cats", "fred");
       // best we can do since there will be one, but possibly more objects in results
       Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(1));
@@ -187,7 +189,7 @@ public class SelectTest extends DefaultGNSTest {
         GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "geoTest-" + RandomString.randomString(12));
         createdGuids.add(testEntry); // save them so we can delete them later
         clientCommands.setLocation(testEntry, 0.0, 0.0);
-        waitSettle(100);
+        waitSettle(WAIT_SETTLE);
       }
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception when we were not expecting it: " + e);
@@ -240,7 +242,7 @@ public class SelectTest extends DefaultGNSTest {
         JSONArray array = new JSONArray(Arrays.asList(25));
         clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
       }
-      waitSettle(100);
+      waitSettle(WAIT_SETTLE);
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
     }
@@ -289,7 +291,7 @@ public class SelectTest extends DefaultGNSTest {
         JSONArray array = new JSONArray(Arrays.asList(25));
         clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
       }
-      waitSettle(100);
+      waitSettle(WAIT_SETTLE);
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
     }
@@ -341,7 +343,7 @@ public class SelectTest extends DefaultGNSTest {
         JSONArray array = new JSONArray(Arrays.asList(25));
         clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
       }
-      waitSettle(100);
+      waitSettle(WAIT_SETTLE);
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception while tryin to create the guids: " + e);
     }
@@ -352,7 +354,7 @@ public class SelectTest extends DefaultGNSTest {
       for (int i = 0; i < result.length(); i++) {
         System.out.println(result.get(i).toString());
       }
-      waitSettle(100);
+      waitSettle(WAIT_SETTLE);
       Assert.assertThat(result.length(), Matchers.equalTo(0));
     } catch (ClientException | IOException | JSONException e) {
       Utils.failWithStackTrace("Exception executing selectQuery: " + e);
@@ -377,7 +379,7 @@ public class SelectTest extends DefaultGNSTest {
         json.put("field1", "value1");
         clientCommands.update(testEntry.getGuid(), json, testEntry);
       }
-      waitSettle(100);
+      waitSettle(WAIT_SETTLE);
     } catch (ClientException | IOException | JSONException e) {
       Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
     }
@@ -434,7 +436,7 @@ public class SelectTest extends DefaultGNSTest {
         json.put("nested", subJson);
         clientCommands.update(testEntry.getGuid(), json, testEntry);
       }
-      waitSettle(100);
+      waitSettle(WAIT_SETTLE);
     } catch (ClientException | IOException | JSONException e) {
       Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
     }
@@ -503,7 +505,7 @@ public class SelectTest extends DefaultGNSTest {
   @Test
   public void test_80_SelectPass() {
     try {
-      waitSettle(100);
+      waitSettle(WAIT_SETTLE);
       JSONArray result = clientCommands.selectQuery(masterGuid, buildLocationQuery(createIndexTestField, AREA_EXTENT));
       for (int i = 0; i < result.length(); i++) {
         System.out.println(result.get(i).toString());

--- a/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
@@ -60,11 +60,14 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SelectTest extends DefaultGNSTest {
 
+   
+  private static final int WAIT_SETTLE = 100;
+
   private static GNSClientCommands clientCommands = null;
   private static GuidEntry masterGuid;
   private static GuidEntry westyEntry;
   private static GuidEntry samEntry;
-  private static final Set<GuidEntry> createdGuids = new HashSet<>();
+  private static final Set<GuidEntry> CREATED_GUIDS = new HashSet<>();
 
   /**
    *
@@ -147,9 +150,7 @@ public class SelectTest extends DefaultGNSTest {
       Utils.failWithStackTrace("Exception when we were not expecting testing DB: " + e);
     }
   }
-  
-  private static final int WAIT_SETTLE = 500;
-
+ 
   /**
    * Check the basic field select command
    */
@@ -187,7 +188,7 @@ public class SelectTest extends DefaultGNSTest {
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
         GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "geoTest-" + RandomString.randomString(12));
-        createdGuids.add(testEntry); // save them so we can delete them later
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
         clientCommands.setLocation(testEntry, 0.0, 0.0);
         waitSettle(WAIT_SETTLE);
       }
@@ -238,7 +239,7 @@ public class SelectTest extends DefaultGNSTest {
         // Remove default all fields / all guids ACL;
         clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
                 GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-        createdGuids.add(testEntry); // save them so we can delete them later
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
         JSONArray array = new JSONArray(Arrays.asList(25));
         clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
       }
@@ -256,25 +257,7 @@ public class SelectTest extends DefaultGNSTest {
       // best we can do should be at least 5, but possibly more objects in results
       Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
     } catch (ClientException | IOException | JSONException e) {
-      Utils.failWithStackTrace("Exception executing selectNear: " + e);
-    }
-
-    try {
-
-      JSONArray rect = new JSONArray();
-      JSONArray upperLeft = new JSONArray();
-      upperLeft.put(1.0);
-      upperLeft.put(1.0);
-      JSONArray lowerRight = new JSONArray();
-      lowerRight.put(-1.0);
-      lowerRight.put(-1.0);
-      rect.put(upperLeft);
-      rect.put(lowerRight);
-      JSONArray result = clientCommands.selectWithin(masterGuid, GNSProtocol.LOCATION_FIELD_NAME.toString(), rect);
-      // best we can do should be at least 5, but possibly more objects in results
-      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
-    } catch (JSONException | ClientException | IOException e) {
-      Utils.failWithStackTrace("Exception executing selectWithin: " + e);
+      Utils.failWithStackTrace("Exception executing selectQuery: " + e);
     }
   }
 
@@ -287,7 +270,7 @@ public class SelectTest extends DefaultGNSTest {
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
         GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "queryTest-" + RandomString.randomString(12));
-        createdGuids.add(testEntry); // save them so we can delete them later
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
         JSONArray array = new JSONArray(Arrays.asList(25));
         clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
       }
@@ -305,25 +288,7 @@ public class SelectTest extends DefaultGNSTest {
       // best we can do should be at least 5, but possibly more objects in results
       Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
     } catch (ClientException | IOException | JSONException e) {
-      Utils.failWithStackTrace("Exception executing selectNear: " + e);
-    }
-
-    try {
-
-      JSONArray rect = new JSONArray();
-      JSONArray upperLeft = new JSONArray();
-      upperLeft.put(1.0);
-      upperLeft.put(1.0);
-      JSONArray lowerRight = new JSONArray();
-      lowerRight.put(-1.0);
-      lowerRight.put(-1.0);
-      rect.put(upperLeft);
-      rect.put(lowerRight);
-      JSONArray result = clientCommands.selectWithin(GNSProtocol.LOCATION_FIELD_NAME.toString(), rect);
-      // best we can do should be at least 5, but possibly more objects in results
-      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
-    } catch (JSONException | ClientException | IOException e) {
-      Utils.failWithStackTrace("Exception executing selectWithin: " + e);
+      Utils.failWithStackTrace("Exception executing selectQuery: " + e);
     }
   }
 
@@ -339,7 +304,7 @@ public class SelectTest extends DefaultGNSTest {
         // Remove default all fields / all guids ACL;
         clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
                 GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-        createdGuids.add(testEntry); // save them so we can delete them later
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
         JSONArray array = new JSONArray(Arrays.asList(25));
         clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
       }
@@ -373,7 +338,7 @@ public class SelectTest extends DefaultGNSTest {
         // Remove default all fields / all guids ACL;
         clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
                 GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-        createdGuids.add(testEntry); // save them so we can delete them later
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
          JSONObject json = new JSONObject();
         json.put(fieldName, Arrays.asList(25));
         json.put("field1", "value1");
@@ -393,25 +358,7 @@ public class SelectTest extends DefaultGNSTest {
       // best we can do should be at least 5, but possibly more objects in results
       Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
     } catch (ClientException | IOException | JSONException e) {
-      Utils.failWithStackTrace("Exception executing selectNear: " + e);
-    }
-
-    try {
-
-      JSONArray rect = new JSONArray();
-      JSONArray upperLeft = new JSONArray();
-      upperLeft.put(1.0);
-      upperLeft.put(1.0);
-      JSONArray lowerRight = new JSONArray();
-      lowerRight.put(-1.0);
-      lowerRight.put(-1.0);
-      rect.put(upperLeft);
-      rect.put(lowerRight);
-      JSONArray result = clientCommands.selectWithin(masterGuid, GNSProtocol.LOCATION_FIELD_NAME.toString(), rect);
-      // best we can do should be at least 5, but possibly more objects in results
-      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
-    } catch (JSONException | ClientException | IOException e) {
-      Utils.failWithStackTrace("Exception executing selectWithin: " + e);
+      Utils.failWithStackTrace("Exception executing selectRecords: " + e);
     }
   }
 
@@ -427,7 +374,7 @@ public class SelectTest extends DefaultGNSTest {
         // Remove default all fields / all guids ACL;
         clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
                 GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-        createdGuids.add(testEntry); // save them so we can delete them later
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
         JSONObject json = new JSONObject();
         json.put(fieldName, Arrays.asList(25));
         json.put("field1", "value1");
@@ -450,25 +397,7 @@ public class SelectTest extends DefaultGNSTest {
       // best we can do should be at least 5, but possibly more objects in results
       Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
     } catch (ClientException | IOException | JSONException e) {
-      Utils.failWithStackTrace("Exception executing selectNear: " + e);
-    }
-
-    try {
-
-      JSONArray rect = new JSONArray();
-      JSONArray upperLeft = new JSONArray();
-      upperLeft.put(1.0);
-      upperLeft.put(1.0);
-      JSONArray lowerRight = new JSONArray();
-      lowerRight.put(-1.0);
-      lowerRight.put(-1.0);
-      rect.put(upperLeft);
-      rect.put(lowerRight);
-      JSONArray result = clientCommands.selectWithin(masterGuid, GNSProtocol.LOCATION_FIELD_NAME.toString(), rect);
-      // best we can do should be at least 5, but possibly more objects in results
-      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
-    } catch (JSONException | ClientException | IOException e) {
-      Utils.failWithStackTrace("Exception executing selectWithin: " + e);
+      Utils.failWithStackTrace("Exception executing selectRecords: " + e);
     }
   }
 
@@ -513,7 +442,7 @@ public class SelectTest extends DefaultGNSTest {
       // best we can do should be at least 5, but possibly more objects in results
       Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(1));
     } catch (JSONException | ClientException | IOException e) {
-      Utils.failWithStackTrace("Exception executing second selectNear: " + e);
+      Utils.failWithStackTrace("Exception executing second selectQuery: " + e);
     }
   }
 
@@ -638,10 +567,10 @@ public class SelectTest extends DefaultGNSTest {
   @Test
   public void test_999_SelectCleanup() {
     try {
-      for (GuidEntry guid : createdGuids) {
+      for (GuidEntry guid : CREATED_GUIDS) {
         clientCommands.guidRemove(masterGuid, guid.getGuid());
       }
-      createdGuids.clear();
+      CREATED_GUIDS.clear();
       clientCommands.guidRemove(masterGuid, westyEntry.getGuid());
       clientCommands.guidRemove(masterGuid, samEntry.getGuid());
     } catch (ClientException | IOException e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
@@ -329,7 +329,7 @@ public class SelectTest extends DefaultGNSTest {
    * Check a query select with unreadable fields
    */
   @Test
-  public void test_56_QuerySelectWorldNotReadable() {
+  public void test_55_QuerySelectWorldNotReadable() {
     String fieldName = "testQueryWorldNotReadable";
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
@@ -358,12 +358,12 @@ public class SelectTest extends DefaultGNSTest {
       Utils.failWithStackTrace("Exception executing selectQuery: " + e);
     }
   }
-  
+
   /**
-   * Check a query select with a reader
+   * Check a query select with a projection
    */
   @Test
-  public void test_58_QuerySelectwithProjection() {
+  public void test_57_QuerySelectwithProjection() {
     String fieldName = "testQueryProjection";
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
@@ -372,17 +372,76 @@ public class SelectTest extends DefaultGNSTest {
         clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
                 GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
         createdGuids.add(testEntry); // save them so we can delete them later
-        JSONArray array = new JSONArray(Arrays.asList(25));
-        clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
+         JSONObject json = new JSONObject();
+        json.put(fieldName, Arrays.asList(25));
+        json.put("field1", "value1");
+        clientCommands.update(testEntry.getGuid(), json, testEntry);
       }
       waitSettle(100);
-    } catch (ClientException | IOException e) {
+    } catch (ClientException | IOException | JSONException e) {
       Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
     }
 
     try {
       String query = "~" + fieldName + " : ($gt: 0)";
-      JSONArray result = clientCommands.selectQueryProjection(masterGuid, query, Arrays.asList(fieldName));
+      JSONArray result = clientCommands.selectRecords(masterGuid, query, Arrays.asList(fieldName));
+      for (int i = 0; i < result.length(); i++) {
+        System.out.println(result.get(i).toString());
+      }
+      // best we can do should be at least 5, but possibly more objects in results
+      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception executing selectNear: " + e);
+    }
+
+    try {
+
+      JSONArray rect = new JSONArray();
+      JSONArray upperLeft = new JSONArray();
+      upperLeft.put(1.0);
+      upperLeft.put(1.0);
+      JSONArray lowerRight = new JSONArray();
+      lowerRight.put(-1.0);
+      lowerRight.put(-1.0);
+      rect.put(upperLeft);
+      rect.put(lowerRight);
+      JSONArray result = clientCommands.selectWithin(masterGuid, GNSProtocol.LOCATION_FIELD_NAME.toString(), rect);
+      // best we can do should be at least 5, but possibly more objects in results
+      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
+    } catch (JSONException | ClientException | IOException e) {
+      Utils.failWithStackTrace("Exception executing selectWithin: " + e);
+    }
+  }
+
+  /**
+   * Check a query select with a projection of all fields
+   */
+  @Test
+  public void test_58_QuerySelectwithProjectionAll() {
+    String fieldName = "testQueryProjectionAll";
+    try {
+      for (int cnt = 0; cnt < 5; cnt++) {
+        GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "queryTest-" + RandomString.randomString(12));
+        // Remove default all fields / all guids ACL;
+        clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
+                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
+        createdGuids.add(testEntry); // save them so we can delete them later
+        JSONObject json = new JSONObject();
+        json.put(fieldName, Arrays.asList(25));
+        json.put("field1", "value1");
+        JSONObject subJson = new JSONObject();
+        subJson.put("subfield", "subvalue1");
+        json.put("nested", subJson);
+        clientCommands.update(testEntry.getGuid(), json, testEntry);
+      }
+      waitSettle(100);
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
+    }
+
+    try {
+      String query = "~" + fieldName + " : ($gt: 0)";
+      JSONArray result = clientCommands.selectRecords(masterGuid, query, null);
       for (int i = 0; i < result.length(); i++) {
         System.out.println(result.get(i).toString());
       }

--- a/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
@@ -166,19 +166,19 @@ public class SelectTest extends DefaultGNSTest {
     }
   }
 
-  /**
-   * Check the basic field select command with world readable records
-   */
-  @Test
-  public void test_31_BasicSelectWorldReadable() {
-    try {
-      JSONArray result = clientCommands.select("cats", "fred");
-      // best we can do since there will be one, but possibly more objects in results
-      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(1));
-    } catch (ClientException | IOException e) {
-      Utils.failWithStackTrace("Exception when we were not expecting it: " + e);
-    }
-  }
+//  /**
+//   * Check the basic field select command with world readable records
+//   */
+//  @Test
+//  public void test_31_BasicSelectWorldReadable() {
+//    try {
+//      JSONArray result = clientCommands.select("cats", "fred");
+//      // best we can do since there will be one, but possibly more objects in results
+//      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(1));
+//    } catch (ClientException | IOException e) {
+//      Utils.failWithStackTrace("Exception when we were not expecting it: " + e);
+//    }
+//  }
 
   /**
    * Check a near and within commands


### PR DESCRIPTION
The old-style select methods are still supported. They return GUIDs. The new methods have an additional fields parameter which can be null to mean all fields. Note that internally null is used to mean old-style select.