### PR TITLE
MOB-1237 (selectRecords should honor ACLs)

### DIFF
--- a/src/edu/umass/cs/gnsserver/gnsapp/Select.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/Select.java
@@ -340,18 +340,19 @@ public class Select {
   }
 
   /**
-   * Filters records and fields from returned records based on ACL checks. 
-   * 
+   * Filters records and fields from returned records based on ACL checks.
+   *
    * @param packet
    * @param records
    * @param reader
    * @param app
-   * @return 
+   * @return
    */
   private static JSONArray aclCheckFilterReturnedRecord(SelectRequestPacket packet, JSONArray records,
           String reader, GNSApplicationInterface<String> app) {
     // First we filter out records
     JSONArray filteredRecords = aclCheckFilterForRecordsArray(packet, records, reader, app);
+    //return filteredRecords;
     // then we filter fields
     return aclCheckFilterFields(packet, filteredRecords, reader, app);
   }
@@ -377,14 +378,15 @@ public class Select {
         List<String> queryFields = getFieldsForQueryType(packet);
         ResponseCode responseCode = NSAuthentication.signatureAndACLCheck(null, guid, null, queryFields, reader,
                 null, null, MetaDataTypeName.READ_WHITELIST, app, true);
-        LOGGER.log(Level.FINE, "ACL check for select: guid={0} queryFields={1} responsecode={2}",
-                new Object[]{guid, queryFields, responseCode});
+        LOGGER.log(Level.FINE, "{0} ACL check for select: guid={0} queryFields={1} responsecode={2}",
+                new Object[]{app.getNodeID(), guid, queryFields, responseCode});
         if (responseCode.isOKResult()) {
           result.put(record);
         }
       } catch (JSONException | InvalidKeyException | InvalidKeySpecException | SignatureException | NoSuchAlgorithmException | FailedDBOperationException | UnsupportedEncodingException e) {
         // ignore json errros
-        LOGGER.log(Level.FINE, "Problem getting guid from json: {0}", e.getMessage());
+        LOGGER.log(Level.FINE, "{0} Problem getting guid from json: {1}",
+                new Object[]{app.getNodeID(), e.getMessage()});
       }
     }
     return result;
@@ -405,18 +407,26 @@ public class Select {
       try {
         JSONObject record = records.getJSONObject(i);
         String guid = record.getString(NameRecord.NAME.getName());
-        Iterator<?> keys = record.keys();
+        // Look at the keys in the values map
+        JSONObject valuesMap = record.getJSONObject(NameRecord.VALUES_MAP.getName());
+        Iterator<?> keys = valuesMap.keys();
         while (keys.hasNext()) {
           String field = (String) keys.next();
-          ResponseCode responseCode = NSAuthentication.signatureAndACLCheck(null, guid, field, null, reader,
-                  null, null, MetaDataTypeName.READ_WHITELIST, app, true);
-          if (!responseCode.isOKResult()) {
-            record.remove(field);
+          if (!InternalField.isInternalField(field)) {
+            LOGGER.log(Level.FINE, "{0} Checking: {1}", new Object[]{app.getNodeID(), field});
+            ResponseCode responseCode = NSAuthentication.signatureAndACLCheck(null, guid, field, null, reader,
+                    null, null, MetaDataTypeName.READ_WHITELIST, app, true);
+            if (!responseCode.isOKResult()) {
+              LOGGER.log(Level.FINE, "{0} Removing: {1}", new Object[]{app.getNodeID(), field});
+              // removing the offending field
+              keys.remove();
+            }
           }
         }
       } catch (JSONException | InvalidKeyException | InvalidKeySpecException | SignatureException | NoSuchAlgorithmException | FailedDBOperationException | UnsupportedEncodingException e) {
         // ignore json errros
-        LOGGER.log(Level.FINE, "Problem getting guid from json: {0}", e.getMessage());
+        LOGGER.log(Level.FINE, "{0} Problem getting guid from json: {1}",
+                new Object[]{app.getNodeID(), e.getMessage()});
       }
     }
     return records;

--- a/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
@@ -128,21 +128,21 @@ public class SelectTest extends DefaultGNSTest {
     }
   }
 
-//  /**
-//   * Check the basic field select command
-//   */
-//  @Test
-//  public void test_030_BasicSelect() {
-//    try {
-//      waitSettle(WAIT_SETTLE);
-//      JSONArray result = client.execute(GNSCommand.select(masterGuid, "cats", "fred")).getResultJSONArray();
-//      //JSONArray result = clientCommands.select(masterGuid, "cats", "fred");
-//      // best we can do since there will be one, but possibly more objects in results
-//      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(1));
-//    } catch (ClientException | IOException e) {
-//      Utils.failWithStackTrace("Exception when we were not expecting it: " + e);
-//    }
-//  }
+  /**
+   * Check the basic field select command
+   */
+  @Test
+  public void test_030_BasicSelect() {
+    try {
+      waitSettle(WAIT_SETTLE);
+      JSONArray result = client.execute(GNSCommand.select(masterGuid, "cats", "fred")).getResultJSONArray();
+      //JSONArray result = clientCommands.select(masterGuid, "cats", "fred");
+      // best we can do since there will be one, but possibly more objects in results
+      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(1));
+    } catch (ClientException | IOException e) {
+      Utils.failWithStackTrace("Exception when we were not expecting it: " + e);
+    }
+  }
 //
 //  /**
 //   * Check a near and within commands
@@ -191,179 +191,241 @@ public class SelectTest extends DefaultGNSTest {
 //    }
 //  }
 //
-//  /**
-//   * Check a query select with a reader
-//   */
-//  @Test
-//  public void test_050_QuerySelectwithReader() {
-//    String fieldName = "testQuery";
-//    try {
-//      for (int cnt = 0; cnt < 5; cnt++) {
-//        GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "queryTest-" + RandomString.randomString(12));
-//        // Remove default all fields / all guids ACL;
-//        clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
-//                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-//        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
-//        JSONArray array = new JSONArray(Arrays.asList(25));
-//        clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
-//      }
-//      waitSettle(WAIT_SETTLE);
-//    } catch (ClientException | IOException e) {
-//      Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
-//    }
-//
-//    try {
-//      String query = "~" + fieldName + " : ($gt: 0)";
-//      JSONArray result = clientCommands.selectQuery(masterGuid, query);
-//      for (int i = 0; i < result.length(); i++) {
-//        System.out.println(result.get(i).toString());
-//      }
-//      // best we can do should be at least 5, but possibly more objects in results
-//      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
-//    } catch (ClientException | IOException | JSONException e) {
-//      Utils.failWithStackTrace("Exception executing selectQuery: " + e);
-//    }
-//  }
-//
-//  /**
-//   * Check a query select with world readable fields
-//   */
-//  @Test
-//  public void test_053_QuerySelectWorldReadable() {
-//    String fieldName = "testQueryWorldReadable";
-//    try {
-//      for (int cnt = 0; cnt < 5; cnt++) {
-//        GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "queryTest-" + RandomString.randomString(12));
-//        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
-//        JSONArray array = new JSONArray(Arrays.asList(25));
-//        clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
-//      }
-//      waitSettle(WAIT_SETTLE);
-//    } catch (ClientException | IOException e) {
-//      Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
-//    }
-//
-//    try {
-//      String query = "~" + fieldName + " : ($gt: 0)";
-//      JSONArray result = clientCommands.selectQuery(query);
-//      for (int i = 0; i < result.length(); i++) {
-//        System.out.println(result.get(i).toString());
-//      }
-//      // best we can do should be at least 5, but possibly more objects in results
-//      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
-//    } catch (ClientException | IOException | JSONException e) {
-//      Utils.failWithStackTrace("Exception executing selectQuery: " + e);
-//    }
-//  }
-//
-//  /**
-//   * Check a query select with unreadable fields
-//   */
-//  @Test
-//  public void test_055_QuerySelectWorldNotReadable() {
-//    String fieldName = "testQueryWorldNotReadable";
-//    try {
-//      for (int cnt = 0; cnt < 5; cnt++) {
-//        GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "queryTest-" + RandomString.randomString(12));
-//        // Remove default all fields / all guids ACL;
-//        clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
-//                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-//        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
-//        JSONArray array = new JSONArray(Arrays.asList(25));
-//        clientCommands.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry);
-//      }
-//      waitSettle(WAIT_SETTLE);
-//    } catch (ClientException | IOException e) {
-//      Utils.failWithStackTrace("Exception while tryin to create the guids: " + e);
-//    }
-//    try {
-//      JSONArray result = null;
-//      String query = "~" + fieldName + " : ($gt: 0)";
-//      result = clientCommands.selectQuery(query);
-//      for (int i = 0; i < result.length(); i++) {
-//        System.out.println(result.get(i).toString());
-//      }
-//      waitSettle(WAIT_SETTLE);
-//      Assert.assertThat(result.length(), Matchers.equalTo(0));
-//    } catch (ClientException | IOException | JSONException e) {
-//      Utils.failWithStackTrace("Exception executing selectQuery: " + e);
-//    }
-//  }
-//
-//  /**
-//   * Check a query select with a projection
-//   */
-//  @Test
-//  public void test_057_QuerySelectwithProjection() {
-//    String fieldName = "testQueryProjection";
-//    try {
-//      for (int cnt = 0; cnt < 5; cnt++) {
-//        GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "queryTest-" + RandomString.randomString(12));
-//        // Remove default all fields / all guids ACL;
-//        clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
-//                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-//        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
-//         JSONObject json = new JSONObject();
-//        json.put(fieldName, Arrays.asList(25));
-//        json.put("field1", "value1");
-//        clientCommands.update(testEntry.getGuid(), json, testEntry);
-//      }
-//      waitSettle(WAIT_SETTLE);
-//    } catch (ClientException | IOException | JSONException e) {
-//      Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
-//    }
-//
-//    try {
-//      String query = "~" + fieldName + " : ($gt: 0)";
-//      JSONArray result = clientCommands.selectRecords(masterGuid, query, Arrays.asList(fieldName));
-//      for (int i = 0; i < result.length(); i++) {
-//        System.out.println(result.get(i).toString());
-//      }
-//      // best we can do should be at least 5, but possibly more objects in results
-//      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
-//    } catch (ClientException | IOException | JSONException e) {
-//      Utils.failWithStackTrace("Exception executing selectRecords: " + e);
-//    }
-//  }
-//
-//  /**
-//   * Check a query select with a projection of all fields
-//   */
-//  @Test
-//  public void test_058_QuerySelectwithProjectionAll() {
-//    String fieldName = "testQueryProjectionAll";
-//    try {
-//      for (int cnt = 0; cnt < 5; cnt++) {
-//        GuidEntry testEntry = clientCommands.guidCreate(masterGuid, "queryTest-" + RandomString.randomString(12));
-//        // Remove default all fields / all guids ACL;
-//        clientCommands.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
-//                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-//        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
-//        JSONObject json = new JSONObject();
-//        json.put(fieldName, Arrays.asList(25));
-//        json.put("field1", "value1");
-//        JSONObject subJson = new JSONObject();
-//        subJson.put("subfield", "subvalue1");
-//        json.put("nested", subJson);
-//        clientCommands.update(testEntry.getGuid(), json, testEntry);
-//      }
-//      waitSettle(WAIT_SETTLE);
-//    } catch (ClientException | IOException | JSONException e) {
-//      Utils.failWithStackTrace("Exception while tryint to create the guids: " + e);
-//    }
-//
-//    try {
-//      String query = "~" + fieldName + " : ($gt: 0)";
-//      JSONArray result = clientCommands.selectRecords(masterGuid, query, null);
-//      for (int i = 0; i < result.length(); i++) {
-//        System.out.println(result.get(i).toString());
-//      }
-//      // best we can do should be at least 5, but possibly more objects in results
-//      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
-//    } catch (ClientException | IOException | JSONException e) {
-//      Utils.failWithStackTrace("Exception executing selectRecords: " + e);
-//    }
-//  }
+
+  /**
+   * Check a query select with a reader
+   */
+  @Test
+  public void test_050_QuerySelectwithReader() {
+    String fieldName = "testQuery";
+    try {
+      for (int cnt = 0; cnt < 5; cnt++) {
+        String queryTestName = "queryTest-" + RandomString.randomString(12);
+        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
+
+        // Remove default all fields / all guids ACL;
+        client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
+                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString()));
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
+        JSONArray array = new JSONArray(Arrays.asList(25));
+        client.execute(GNSCommand.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry));
+      }
+      waitSettle(WAIT_SETTLE);
+    } catch (ClientException | IOException e) {
+      Utils.failWithStackTrace("Exception while trying to create the guids: " + e);
+    }
+
+    try {
+      String query = "~" + fieldName + " : ($gt: 0)";
+      JSONArray result = client.execute(GNSCommand.selectQuery(masterGuid, query)).getResultJSONArray();
+      for (int i = 0; i < result.length(); i++) {
+        System.out.println(result.get(i).toString());
+      }
+      // best we can do should be at least 5, but possibly more objects in results
+      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception executing selectQuery: " + e);
+    }
+  }
+
+  /**
+   * Check a query select with world readable fields
+   */
+  @Test
+  public void test_053_QuerySelectWorldReadable() {
+    String fieldName = "testQueryWorldReadable";
+    try {
+      for (int cnt = 0; cnt < 5; cnt++) {
+        String queryTestName = "queryTest-" + RandomString.randomString(12);
+        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
+        JSONArray array = new JSONArray(Arrays.asList(25));
+        client.execute(GNSCommand.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry));
+      }
+      waitSettle(WAIT_SETTLE);
+    } catch (ClientException | IOException e) {
+      Utils.failWithStackTrace("Exception while trying to create the guids: " + e);
+    }
+
+    try {
+      String query = "~" + fieldName + " : ($gt: 0)";
+      JSONArray result = client.execute(GNSCommand.selectQuery(query)).getResultJSONArray();
+      for (int i = 0; i < result.length(); i++) {
+        System.out.println(result.get(i).toString());
+      }
+      // best we can do should be at least 5, but possibly more objects in results
+      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception executing selectQuery: " + e);
+    }
+  }
+
+  /**
+   * Check a query select with unreadable fields
+   */
+  @Test
+  public void test_055_QuerySelectWorldNotReadable() {
+    String fieldName = "testQueryWorldNotReadable";
+    try {
+      for (int cnt = 0; cnt < 5; cnt++) {
+        String queryTestName = "queryTest-" + RandomString.randomString(12);
+        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
+        // Remove default all fields / all guids ACL;
+        client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
+                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString()));
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
+        JSONArray array = new JSONArray(Arrays.asList(25));
+        client.execute(GNSCommand.fieldReplaceOrCreateList(testEntry.getGuid(), fieldName, array, testEntry));
+      }
+      waitSettle(WAIT_SETTLE);
+    } catch (ClientException | IOException e) {
+      Utils.failWithStackTrace("Exception while tryin to create the guids: " + e);
+    }
+    try {
+      JSONArray result = null;
+      String query = "~" + fieldName + " : ($gt: 0)";
+      result = client.execute(GNSCommand.selectQuery(query)).getResultJSONArray();
+      for (int i = 0; i < result.length(); i++) {
+        System.out.println(result.get(i).toString());
+      }
+      Assert.assertThat(result.length(), Matchers.equalTo(0));
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception executing selectQuery: " + e);
+    }
+  }
+
+  /**
+   * Check a query select with a projection
+   */
+  @Test
+  public void test_057_QuerySelectwithProjection() {
+    String fieldName = "testQueryProjection";
+    try {
+      for (int cnt = 0; cnt < 5; cnt++) {
+        String queryTestName = "queryTest-" + RandomString.randomString(12);
+        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
+        // Remove default all fields / all guids ACL;
+        client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
+                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString()));
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
+        JSONObject json = new JSONObject();
+        json.put(fieldName, Arrays.asList(25));
+        json.put("field1", "value1");
+        client.execute(GNSCommand.update(testEntry.getGuid(), json, testEntry));
+      }
+      waitSettle(WAIT_SETTLE);
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception while trying to create the guids: " + e);
+    }
+
+    try {
+      String query = "~" + fieldName + " : ($gt: 0)";
+      JSONArray result = client.execute(GNSCommand.selectRecords(masterGuid,
+              query, Arrays.asList(fieldName))).getResultJSONArray();
+      for (int i = 0; i < result.length(); i++) {
+        System.out.println(result.get(i).toString());
+      }
+      // best we can do should be at least 5, but possibly more objects in results
+      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception executing selectRecords: " + e);
+    }
+  }
+
+  /**
+   * Check a query select with a projection of all fields
+   */
+  @Test
+  public void test_058_QuerySelectwithProjectionAll() {
+    String fieldName = "testQueryProjectionAll";
+    try {
+      for (int cnt = 0; cnt < 5; cnt++) {
+        String queryTestName = "queryTest-" + RandomString.randomString(12);
+        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
+        // Remove default all fields / all guids ACL;
+        client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
+                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString()));
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
+        JSONObject json = new JSONObject();
+        json.put(fieldName, Arrays.asList(25));
+        json.put("field1", "value1");
+        JSONObject subJson = new JSONObject();
+        subJson.put("subfield", "subvalue1");
+        json.put("nested", subJson);
+        client.execute(GNSCommand.update(testEntry.getGuid(), json, testEntry));
+      }
+      waitSettle(WAIT_SETTLE);
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception while trying to create the guids: " + e);
+    }
+
+    try {
+      String query = "~" + fieldName + " : ($gt: 0)";
+      JSONArray result = client.execute(GNSCommand.selectRecords(masterGuid, query, null)).getResultJSONArray();
+      for (int i = 0; i < result.length(); i++) {
+        System.out.println(result.get(i).toString());
+      }
+      // best we can do should be at least 5, but possibly more objects in results
+      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception executing selectRecords: " + e);
+    }
+  }
+
+  /**
+   * Check a query select with a projection
+   */
+  @Test
+  public void test_059_QuerySelectwithProjectionSomeFieldsNotAccessible() {
+    String fieldName = "testQueryProjectionSomeFieldsNotAccessible";
+    try {
+      for (int cnt = 0; cnt < 5; cnt++) {
+        String queryTestName = "queryTest-" + RandomString.randomString(12);
+        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
+        // Remove default all fields / all guids ACL;
+        client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
+                GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString()));
+        // Also remove masterGuid access to entire record
+        client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
+                GNSProtocol.ENTIRE_RECORD.toString(), masterGuid.getGuid()));
+        CREATED_GUIDS.add(testEntry); // save them so we can delete them later
+        JSONObject json = new JSONObject();
+        json.put(fieldName, Arrays.asList(25));
+        json.put("field1", "value1");
+        json.put("inaccessableField", "someValue");
+        client.execute(GNSCommand.update(testEntry.getGuid(), json, testEntry));
+        // Add masterguid access to fieldName so that the query will work
+        client.execute(GNSCommand.aclAdd(AclAccessType.READ_WHITELIST, testEntry,
+                fieldName, masterGuid.getGuid()));
+        // Add masterguid access to field1
+        client.execute(GNSCommand.aclAdd(AclAccessType.READ_WHITELIST, testEntry,
+                "field1", masterGuid.getGuid()));
+        // Set up the ACL so the masterGuid can't read this field
+        client.execute(GNSCommand.fieldCreateAcl(AclAccessType.READ_WHITELIST, testEntry,
+                "inaccessableField", testEntry.getGuid()));
+      }
+      waitSettle(WAIT_SETTLE);
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception while trying to create the guids: " + e);
+    }
+    try {
+      String query = "~" + fieldName + " : ($gt: 0)";
+      JSONArray result = client.execute(GNSCommand.selectRecords(masterGuid, query, null)).getResultJSONArray();
+      for (int i = 0; i < result.length(); i++) {
+        System.out.println(result.get(i).toString());
+      }
+      // best we can do should be at least 5, but possibly more objects in results
+      Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
+    } catch (ClientException | IOException | JSONException e) {
+      Utils.failWithStackTrace("Exception executing selectRecords: " + e);
+    }
+  }
 
   private static String createIndexTestField;
 
@@ -394,8 +456,6 @@ public class SelectTest extends DefaultGNSTest {
 //      Utils.failWithStackTrace("Exception while creating index: " + e);
 //    }
 //  }
-  
-  
 //
 //  /**
 //   * Check a query with the index
@@ -475,7 +535,6 @@ public class SelectTest extends DefaultGNSTest {
 //      Utils.failWithStackTrace("Exception executing second selectNear: " + e);
 //    }
 //  }
-
   /**
    * Check an empty query
    */
@@ -491,7 +550,7 @@ public class SelectTest extends DefaultGNSTest {
       Utils.failWithStackTrace("Exception executing empty query " + e);
     }
   }
-  
+
   /**
    * Check an empty query
    */
@@ -507,7 +566,7 @@ public class SelectTest extends DefaultGNSTest {
       Utils.failWithStackTrace("Exception executing empty query " + e);
     }
   }
-  
+
   /**
    * Check an empty query
    */
@@ -523,7 +582,7 @@ public class SelectTest extends DefaultGNSTest {
       Utils.failWithStackTrace("Exception executing empty query " + e);
     }
   }
-  
+
   /**
    * Check an empty query
    */
@@ -591,9 +650,9 @@ public class SelectTest extends DefaultGNSTest {
         //clientCommands.guidRemove(masterGuid, guid.getGuid());
       }
       CREATED_GUIDS.clear();
-       client.execute(GNSCommand.removeGUID(masterGuid, westyEntry.getGuid()));
+      client.execute(GNSCommand.removeGUID(masterGuid, westyEntry.getGuid()));
       //clientCommands.guidRemove(masterGuid, westyEntry.getGuid());
-       client.execute(GNSCommand.removeGUID(masterGuid, samEntry.getGuid()));
+      client.execute(GNSCommand.removeGUID(masterGuid, samEntry.getGuid()));
       //clientCommands.guidRemove(masterGuid, samEntry.getGuid());
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception during cleanup: " + e);

--- a/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
@@ -426,6 +426,10 @@ public class SelectTest extends DefaultGNSTest {
       }
       // best we can do should be at least 5, but possibly more objects in results
       Assert.assertThat(result.length(), Matchers.greaterThanOrEqualTo(5));
+      // Make sure that one of them has the field we want and
+      Assert.assertTrue(result.getJSONObject(0).has("field1"));
+      // doesn't have the field we can't see
+      Assert.assertFalse(result.getJSONObject(0).has("inaccessableField"));
     } catch (JSONException e) {
       //} catch (ClientException | IOException | JSONException e) {
       Utils.failWithStackTrace("Exception executing selectRecords: " + e);


### PR DESCRIPTION
selectRecords should honor ACLs in this way for fields that have restricted access:
1) fields that are not accessible in the query should result in no records being returned (existed before)
2) fields that are not accessible in the fields to be returned should be pruned, but the remaining fields can be returned