### PR TITLE
Added support to setMaximumOutstandingAppRequests in the GNSClient

### DIFF
--- a/conf/gnsclient.ec2diffport.properties
+++ b/conf/gnsclient.ec2diffport.properties
@@ -1,0 +1,13 @@
+# The list of property names and values that can be specified here
+# may be found in the enum PaxosConfig.PC in PaxosConfig.java.
+
+# properties for connecting to a 3 node server running on a remote host 
+# you'll want to change the ip address below as well as make sure there
+# is a corresponding server properties file
+
+CLIENT_SSL_MODE=SERVER_AUTH
+
+reconfigurator.RC4.1=172.30.0.53:2158
+reconfigurator.RC4.2=172.30.0.53:2168
+reconfigurator.RC4.3=172.30.3.241:2178
+reconfigurator.RC4.4=172.30.3.241:2188

--- a/conf/gnsclient.ec2sameport.properties
+++ b/conf/gnsclient.ec2sameport.properties
@@ -1,0 +1,13 @@
+# The list of property names and values that can be specified here
+# may be found in the enum PaxosConfig.PC in PaxosConfig.java.
+
+# properties for connecting to a 3 node server running on a remote host 
+# you'll want to change the ip address below as well as make sure there
+# is a corresponding server properties file
+
+CLIENT_SSL_MODE=SERVER_AUTH
+
+reconfigurator.RC4.1=172.30.0.53:2158
+reconfigurator.RC4.2=172.30.0.53:2168
+reconfigurator.RC4.3=172.30.3.241:2158
+reconfigurator.RC4.4=172.30.3.241:2168

--- a/conf/gnsserver.ec2diffport.properties
+++ b/conf/gnsserver.ec2diffport.properties
@@ -1,0 +1,48 @@
+# The list of property names and values that can be specified here
+# may be found in the enum PaxosConfig.PC, ReconfigurationConfig.RC,
+# GNSConfig.GNSC (for GNS servers), and GNSClientConfig.GNSCC (for GNS
+# clients). 
+
+# properties for starting a 3 node server running on a test EC2 remote host 
+
+ENABLE_INSTRUMENTATION=false
+
+ENABLE_DISKMAP=true
+IN_MEMORY_DB=true
+
+CLIENT_SSL_MODE=SERVER_AUTH
+SERVER_SSL_MODE=MUTUAL_AUTH
+
+DEMAND_PROFILE_TYPE=edu.umass.cs.gnsserver.gnsapp.NullDemandProfile
+#DEMAND_PROFILE_TYPE=edu.umass.cs.gnsserver.gnsapp.LocationBasedDemandProfile
+
+# use with ReconfigurableNode <nodeID>*
+APPLICATION=edu.umass.cs.gnsserver.gnsapp.GNSApp
+
+# Change the ip addresses below for your server(s) as well and make
+# sure there is a corresponding client properties file
+
+active.GNSApp4.1=172.30.0.53:24403
+active.GNSApp4.2=172.30.0.53:25403
+active.GNSApp4.3=172.30.3.241:24403
+active.GNSApp4.4=172.30.3.241:25403
+
+reconfigurator.RC4.1=172.30.0.53:2158
+reconfigurator.RC4.2=172.30.0.53:2168
+reconfigurator.RC4.3=172.30.3.241:2178
+reconfigurator.RC4.4=172.30.3.241:2188
+
+# Specifying ssl properties or more generally system properties in
+# this file is not necessary but can be done. Command-line system
+# properties values take precedence over any values set here.
+-Djavax.net.ssl.keyStorePassword=qwerty
+-Djavax.net.ssl.keyStore=conf/keyStore/node100.jks
+-Djavax.net.ssl.trustStorePassword=qwerty
+-Djavax.net.ssl.trustStore=conf/keyStore/node100.jks
+
+# distributed install properties
+USERNAME=ubuntu
+
+ENABLE_EMAIL_VERIFICATION=false
+#-DappArgs=-test -disableEmailVerification
+

--- a/conf/gnsserver.ec2sameport.properties
+++ b/conf/gnsserver.ec2sameport.properties
@@ -1,0 +1,48 @@
+# The list of property names and values that can be specified here
+# may be found in the enum PaxosConfig.PC, ReconfigurationConfig.RC,
+# GNSConfig.GNSC (for GNS servers), and GNSClientConfig.GNSCC (for GNS
+# clients). 
+
+# properties for starting a 3 node server running on a test EC2 remote host 
+
+ENABLE_INSTRUMENTATION=false
+
+ENABLE_DISKMAP=true
+IN_MEMORY_DB=true
+
+CLIENT_SSL_MODE=SERVER_AUTH
+SERVER_SSL_MODE=MUTUAL_AUTH
+
+DEMAND_PROFILE_TYPE=edu.umass.cs.gnsserver.gnsapp.NullDemandProfile
+#DEMAND_PROFILE_TYPE=edu.umass.cs.gnsserver.gnsapp.LocationBasedDemandProfile
+
+# use with ReconfigurableNode <nodeID>*
+APPLICATION=edu.umass.cs.gnsserver.gnsapp.GNSApp
+
+# Change the ip addresses below for your server(s) as well and make
+# sure there is a corresponding client properties file
+
+active.GNSApp4.1=172.30.0.53:24403
+active.GNSApp4.2=172.30.0.53:25403
+active.GNSApp4.3=172.30.3.241:24403
+active.GNSApp4.4=172.30.3.241:25403
+
+reconfigurator.RC4.1=172.30.0.53:2158
+reconfigurator.RC4.2=172.30.0.53:2168
+reconfigurator.RC4.3=172.30.3.241:2158
+reconfigurator.RC4.4=172.30.3.241:2168
+
+# Specifying ssl properties or more generally system properties in
+# this file is not necessary but can be done. Command-line system
+# properties values take precedence over any values set here.
+-Djavax.net.ssl.keyStorePassword=qwerty
+-Djavax.net.ssl.keyStore=conf/keyStore/node100.jks
+-Djavax.net.ssl.trustStorePassword=qwerty
+-Djavax.net.ssl.trustStore=conf/keyStore/node100.jks
+
+# distributed install properties
+USERNAME=ubuntu
+
+ENABLE_EMAIL_VERIFICATION=false
+#-DappArgs=-test -disableEmailVerification
+

--- a/src/edu/umass/cs/gnsclient/client/GNSClient.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSClient.java
@@ -597,6 +597,16 @@ public class GNSClient {
 				throws RequestParseException {
 			return GNSAppUtil.getRequestStatic(bytes, header, unstringer);
 		}
+		
+		/**
+		 * Sets the maximum outstanding app requests for 
+		 * {@link ReconfigurableAppClientAsync}
+		 * @param n The maximum number of outstanding app requests to allow.
+		 */
+		public void setMaximumOutstandingAppRequests(int n)
+		{
+			ReconfigurableAppClientAsync.setMaxOutstandingAppRequests(n);
+		}
 	} // End of AsyncClient
 
 	/**
@@ -624,6 +634,17 @@ public class GNSClient {
 	public GNSClient setForcedTimeout(long t) {
 		this.forcedTimeout = t;
 		return this;
+	}
+	
+	/**
+	 * Sets the maximum outstanding app requests for the {@link GNSClient},
+	 * which internally sets the maximum outstanding app requests for 
+	 * {@link ReconfigurableAppClientAsync}
+	 * @param n The maximum number of outstanding app requests to allow.
+	 */
+	public void setMaximumOutstandingAppRequests(int n)
+	{
+		asyncClient.setMaximumOutstandingAppRequests(n);
 	}
 
 	/* **************** Start of execute methods ****************** */


### PR DESCRIPTION
I have added support to setMaximumOutstandingAppRequests in the GNSClient, which is needed to use the non-blocking API of the GNSClient.