### PR TITLE
Add a new throughput test to prevent performance degration in the future commits

### DIFF
--- a/bin/gpEnv.sh
+++ b/bin/gpEnv.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# ssh key to be used for remote installs
+SSH_KEY=
+
+# Remote install location if different from the remote home directory.
+# Setting this value to "~" is likely incorrect because it will get
+# replaced by the local home directory path.
+INSTALL_PATH_PREFIX=

--- a/src/edu/umass/cs/gnsclient/client/testing/GNSClientCapacityTest.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/GNSClientCapacityTest.java
@@ -32,7 +32,6 @@ import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnscommon.GNSProtocol;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
 import edu.umass.cs.gnscommon.exceptions.client.DuplicateNameException;
-import edu.umass.cs.gnscommon.packets.CommandPacket;
 import edu.umass.cs.utils.Config;
 import edu.umass.cs.utils.DefaultTest;
 import edu.umass.cs.utils.DelayProfiler;
@@ -316,7 +315,7 @@ public class GNSClientCapacityTest extends DefaultTest {
 	 * @throws Exception
 	 */
 	@Test
-	public void test_02_ParralelWriteCapacity() throws Exception {
+	public void test_02_ParallelWriteCapacity() throws Exception {
 		int numWrites = numWriteAndRemove;
 		long t = System.currentTimeMillis();
 		for (int i=0; i<numWrites; i++){
@@ -345,7 +344,7 @@ public class GNSClientCapacityTest extends DefaultTest {
 	 * @throws IOException
 	 */
 	@Test
-	public void test_03_ParrallelWriteWithACLCapacity() throws InterruptedException, ClientException, IOException{
+	public void test_03_ParallelWriteWithACLCapacity() throws InterruptedException, ClientException, IOException{
 		reset();
 		// The old GNS ACL implementation does not allow a GUID in ENTIRE_RECORD's ACL to write into a sub field.
 		clients[0].execute(GNSCommand.aclAdd(AclAccessType.WRITE_WHITELIST, 

--- a/test/edu/umass/cs/gnsclient/client/singletests/SystemThruputTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SystemThruputTest.java
@@ -1,0 +1,210 @@
+package edu.umass.cs.gnsclient.client.singletests;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.json.JSONException;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import edu.umass.cs.gnsclient.client.GNSClient;
+import edu.umass.cs.gnsclient.client.GNSCommand;
+import edu.umass.cs.gnsclient.client.util.GuidEntry;
+import edu.umass.cs.gnsclient.client.util.GuidUtils;
+import edu.umass.cs.gnscommon.exceptions.client.ClientException;
+import edu.umass.cs.gnsserver.utils.DefaultGNSTest;
+import edu.umass.cs.utils.Util;
+import edu.umass.cs.utils.Utils;
+
+/**
+ * This test is used to ensure that the system performance 
+ * (in terms of throughput, i.e., reqs/sec) of unsigned read 
+ * and signed write won't be degraded in the future commits 
+ * to the master branch.
+ * If the performance of any of these two operations decreases
+ * to lower than 80% of the threshold defined in this test,
+ * this test will fail.
+ * 
+ * @author gaozy
+ *
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class SystemThruputTest extends DefaultGNSTest {
+	
+	private static GNSClient[] clients = null;
+	private static GuidEntry accountGuid;
+	
+	private static String testField;
+	private static String testValue;
+	
+	private static ThreadPoolExecutor executor;
+	
+	private static final int numWrites = 50000;
+	private static final int numReads = 400000;
+	
+	// TODO: not sure 10 is enough to saturate the servers on Travis CI, as there are 3 servers
+	private final static int numClients = 10;
+	
+	private static int numFinishedOps = 0;
+	private static long lastOpFinishedTime = System.currentTimeMillis();
+	
+	synchronized static void incrFinishedOps() {
+		numFinishedOps++;
+		lastOpFinishedTime = System.currentTimeMillis();
+	}
+	
+	private void reset() {
+		numFinishedOps = 0;
+		lastOpFinishedTime = System.currentTimeMillis();
+	}
+
+	
+	/**
+	 * 
+	 */
+	public SystemThruputTest() {
+		clients = new GNSClient[numClients];
+		// initialize numClients clients
+		for (int i=0; i<numClients; i++){
+			try {
+				clients[i] = new GNSClient();
+			} catch (IOException e) {
+				Utils.failWithStackTrace("Exception creating clients: ", e);
+			}
+		}
+		
+		try {
+			accountGuid = GuidUtils.lookupOrCreateAccountGuid(clients[0], "ACCOUNT_GUID", "password");
+		} catch (Exception e) {
+			Utils.failWithStackTrace("Exception creating client: ", e);
+		}
+		
+		// initialize thread pool executor
+		executor = (ThreadPoolExecutor) Executors
+				.newFixedThreadPool(50*numClients);
+				
+		SecureRandom random = new SecureRandom();
+		// initialize random field and value: 10-byte string
+		testField = new BigInteger(80, random).toString();
+		testValue = new BigInteger(80, random).toString();
+		
+	}
+	
+	/**
+	 * Update the {testField:testValue} to user json
+	 */
+	@Test
+	public void test_01_CreateFieldAndValue() {
+		try {
+			clients[0].execute(GNSCommand.fieldUpdate(accountGuid, testField, testValue));
+			assert(client.execute(GNSCommand.fieldRead(accountGuid, testField)).getResultJSONObject().getString(testField)
+					.equals(testValue));
+		} catch (ClientException | IOException | JSONException e) {
+			Utils.failWithStackTrace("Exception updating a field: ", e);
+		}
+	}
+	
+	/**
+	 * This warm-up round is used to warm up not just the server JVMs but also the client.
+	 * Without this round, the performance may not stablize. 
+	 */
+	public void test_10_Warmup() {
+		
+	}
+	
+	
+	/**
+	 * TODO: threshold
+	 */
+	@Test
+	public void test_11_ParallelWriteCapacity() {
+		long t = System.currentTimeMillis();
+		for (int i=0; i<numWrites; i++){
+			blockingSignedWrite(i % numClients, accountGuid);
+		}
+		System.out.print("[total_writes=" + numWrites+": ");
+		int lastCount = 0;
+		while (numFinishedOps < numWrites) {
+			if(numFinishedOps>lastCount)  {
+				lastCount = numFinishedOps;
+				System.out.print(numFinishedOps + "@" + Util.df(numFinishedOps * 1.0 / (lastOpFinishedTime - t))+"K/s ");
+			}
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {
+				//swallow exception
+			}
+		}
+		System.out.print("] ");
+		System.out.print("parallel_write_rate="
+				+ Util.df(numWrites * 1.0 / (lastOpFinishedTime - t))
+				+ "K/s");
+	}
+	
+	/**
+	 * TODO: threshold
+	 */
+	@Test
+	public void test_12_ParallelReadCapacity() {
+		reset();
+		long t = System.currentTimeMillis();
+		for (int i = 0; i < numReads; i++) {
+			blockingUnsignedRead(i % numClients, accountGuid);
+		}
+		int j = 1;
+		System.out.print("[total_unsigned_reads=" + numReads+": ");
+		while (numFinishedOps < numReads) {
+			if (numFinishedOps >= j) {
+				j *= 2;
+				System.out.print(numFinishedOps + "@" + Util.df(numFinishedOps * 1.0 / (lastOpFinishedTime - t))+"K/s ");
+			}
+			try {
+				Thread.sleep(500);
+			} catch (InterruptedException e) {
+				// swallow exception
+			}
+		}
+		System.out.print("] ");
+		System.out.print("parallel_unsigned_read_rate="
+				+ Util.df(numReads * 1.0 / (lastOpFinishedTime - t))
+				+ "K/s");
+	}
+	
+	
+	private void blockingUnsignedRead(int clientIndex, GuidEntry guid) {
+		executor.submit(new Runnable() {
+			public void run() {
+				try {					
+					assert(clients[clientIndex].execute(GNSCommand.fieldRead(guid.getGuid(), 
+								testField, null)).getResultJSONObject().getString(testField).equals(testValue));					
+				} catch (IOException e) {
+					Utils.failWithStackTrace("Exception reading a field: ", e);
+				} catch (JSONException | ClientException e){
+					// swallow the exception as it is very possible a timeout exception
+				}
+				incrFinishedOps();
+			}
+		});
+	}
+	
+	private void blockingSignedWrite(int clientIndex, GuidEntry guid) {
+		executor.submit(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					clients[clientIndex].execute(GNSCommand.fieldUpdate(guid, testField, testValue));					
+				} catch (IOException e) {
+					Utils.failWithStackTrace("Exception updating a field: ", e);
+				} catch (ClientException e) {
+					// swallow the timeout exception
+				}
+				incrFinishedOps();
+			}			
+		});
+	}
+	
+}

--- a/test/edu/umass/cs/gnsclient/client/singletests/SystemThruputTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SystemThruputTest.java
@@ -44,10 +44,10 @@ public class SystemThruputTest extends DefaultGNSTest {
 	private static ThreadPoolExecutor executor;
 	
 	private static final int numWrites = 10000;
-	private static final int numReads = 100000;
+	private static final int numReads = 200000;
 	
-	// TODO: not sure 10 is enough to saturate the servers on Travis CI, as there are 3 servers
-	private final static int numClients = 10;
+	// TODO: reduce numClients to 1, it is not enough to saturate the servers on Travis CI
+	private final static int numClients = 1;
 	
 	private static int numFinishedOps = 0;
 	private static long lastOpFinishedTime = System.currentTimeMillis();

--- a/test/edu/umass/cs/gnsclient/client/singletests/SystemThruputTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SystemThruputTest.java
@@ -43,8 +43,8 @@ public class SystemThruputTest extends DefaultGNSTest {
 	
 	private static ThreadPoolExecutor executor;
 	
-	private static final int numWrites = 50000;
-	private static final int numReads = 400000;
+	private static final int numWrites = 10000;
+	private static final int numReads = 100000;
 	
 	// TODO: not sure 10 is enough to saturate the servers on Travis CI, as there are 3 servers
 	private final static int numClients = 10;


### PR DESCRIPTION
This pull request contains a single test SystemThruputTest in test/edu/umass/cs/gnsclient/client/singletests, which is used to prevent performance degration in the future commits. 
The test only focuses on two operations: unsigned read and signed write.
Future commits to the master branch must guarantee that the system throughput can not drop lower than 80% of the threshold set in this test.

TODO: the threshold has not been set in this commit, we need to run it on Travis CI first to get the throughput first.

NOTE: this pull request is ready to be merged into master branch. 