### PR TITLE
Configurable custom select policy support

### DIFF
--- a/src/edu/umass/cs/gnsclient/client/GNSCommand.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSCommand.java
@@ -223,7 +223,7 @@ public class GNSCommand extends CommandPacket {
    * @return CommandPacket
    * @throws ClientException
    */
-  protected static final CommandPacket fieldCreateIndex(GuidEntry GUID,
+  public static final CommandPacket fieldCreateIndex(GuidEntry GUID,
           String field, String index) throws ClientException {
     return getCommand(CommandType.CreateIndex, GUID,
             GNSProtocol.GUID.toString(), GUID.getGuid(),

--- a/src/edu/umass/cs/gnsserver/gnsapp/GNSApp.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/GNSApp.java
@@ -360,7 +360,7 @@ public class GNSApp extends AbstractReconfigurablePaxosApp<String> implements
         	{
         		// In the select command , doNotReplyToClient will be false,
         		// as this NS is the originating NS for the select request.
-        		// checking this here because the CNS select internally replies to the client.
+        		// checking this here so that a custom select can internally reply to a client.
         		assert(!doNotReplyToClient);
         		this.selectPolicy.handleSelectRequestFromClient((CommandPacket) request);
         	}

--- a/src/edu/umass/cs/gnsserver/gnsapp/GNSApplicationInterface.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/GNSApplicationInterface.java
@@ -25,7 +25,7 @@ import edu.umass.cs.gnscommon.packets.CommandPacket;
 import edu.umass.cs.gnsserver.activecode.ActiveCodeHandler;
 import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.ClientRequestHandlerInterface;
 import edu.umass.cs.gnsserver.gnsapp.recordmap.BasicRecordMap;
-import edu.umass.cs.reconfiguration.interfaces.ReconfigurableNodeConfig;
+import edu.umass.cs.nio.interfaces.SSLMessenger;
 
 import java.io.IOException;
 
@@ -106,5 +106,11 @@ public interface GNSApplicationInterface<NodeIDType> {
    * @return the active code handler
    */
   ActiveCodeHandler getActiveCodeHandler();
+  
+  /**
+   *
+   * @return the SSLMessenger
+   */
+  public SSLMessenger<String, JSONObject> getSSLMessenger();
 
 }

--- a/src/edu/umass/cs/gnsserver/gnsapp/Select.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/Select.java
@@ -570,9 +570,14 @@ public class Select {
     }
   }
 
-  // Converts a record from the database into something we can return to 
-  // the user. Adds the "_GUID" and removes internal fields.
-  private static List<JSONObject> filterAndMassageRecords(Set<JSONObject> records) {
+  /**
+   * Converts a record from the database into a format that we can return to 
+   * the user. Adds the "_GUID" and removes internal fields.
+   * 
+   * @param records
+   * @return
+   */
+  public static List<JSONObject> filterAndMassageRecords(Set<JSONObject> records) {
     List<JSONObject> result = new ArrayList<>();
     for (JSONObject record : records) {
       try {
@@ -595,9 +600,14 @@ public class Select {
     return result;
   }
 
-  // Pulls the guids out of the record to return to the user for "old-style" 
-  // select calls.
-  private static Set<String> extractGuidsFromRecords(Set<JSONObject> records) {
+  /**
+   * Pulls the guids out of the record to return to the user for "old-style" 
+   * select calls.
+   * 
+   * @param records
+   * @return
+   */ 
+  public static Set<String> extractGuidsFromRecords(Set<JSONObject> records) {
     Set<String> result = new HashSet<>();
     for (JSONObject json : records) {
       try {
@@ -665,8 +675,17 @@ public class Select {
     return jsonRecords;
   }
 
-  // Takes the JSON records that are returned from an NS and stuffs the into the NSSelectInfo record
-  private static void processJSONRecords(JSONArray jsonArray, NSSelectInfo info,
+  /**
+   * Takes the JSON records that are returned from an NS and 
+   * stuffs the into the {@link NSSelectInfo} record
+   * 
+   * @param jsonArray
+   * @param info
+   * @param ar
+   * 
+   * @throws JSONException if there is any JSON parsing exception. 
+   */
+  public static void processJSONRecords(JSONArray jsonArray, NSSelectInfo info,
           GNSApplicationInterface<String> ar) throws JSONException {
     int length = jsonArray.length();
     LOGGER.log(Level.FINE,

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/CommandHandler.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/CommandHandler.java
@@ -77,6 +77,16 @@ public class CommandHandler {
             commandModule.lookupCommand(PacketUtils.getCommand(packet)),
             app.getRequestHandler(), doNotReplyToClient, app);
   }
+  
+  /**
+   * Returns the command module. Mainly used
+   * by custom selects, outside this class. 
+   * @return
+   */
+  public static CommandModule getCommandModule()
+  {
+	  return commandModule;
+  }
 
   private static final long LONG_DELAY_THRESHOLD = 1;
 
@@ -161,7 +171,16 @@ public class CommandHandler {
 
   }
 
-  private static CommandPacket addMessageWithoutSignatureToCommand(
+  /**
+   * FIXME: aditya: Made this method public, as it needs to be used
+   * by the custom select. But not sure what this method actually does 
+   * for adding the documentation.
+   * 
+   * @param commandPacket
+   * @return
+   * @throws JSONException
+   */
+  public static CommandPacket addMessageWithoutSignatureToCommand(
           CommandPacket commandPacket) throws JSONException {
     JSONObject command = PacketUtils.getCommand(commandPacket);
     CommandUtils.addMessageWithoutSignatureToJSON(command);

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/FieldAccess.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/FieldAccess.java
@@ -604,8 +604,18 @@ public class FieldAccess {
       return null;
     }
   }
-
-  private static boolean signatureCheckForSelect(String reader, String signature,
+  
+  
+  /**
+   * Performs the signature checks for the select requests. 
+   * 
+   * @param reader
+   * @param signature
+   * @param message
+   * @param app
+   * @return
+   */
+  public static boolean signatureCheckForSelect(String reader, String signature,
           String message, GNSApplicationInterface<String> app) {
     try {
       if (signature == null || reader == null) {

--- a/src/edu/umass/cs/gnsserver/gnsapp/packet/BasicPacketWithClientAddress.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/packet/BasicPacketWithClientAddress.java
@@ -38,8 +38,12 @@ import org.json.JSONObject;
 public abstract class BasicPacketWithClientAddress extends BasicPacket {
 
   private final static String CLIENT_ADDRESS = "clientAddress";
-
-  private InetSocketAddress clientAddress = null;
+  
+  // stores the address of the client that sent the request.
+  protected InetSocketAddress clientAddress = null;
+  
+  // stores the address of the server that receives the request.
+  protected InetSocketAddress serverListeningAddress = null;
 
   /**
    * Creates a BasicPacket.
@@ -92,5 +96,14 @@ public BasicPacketWithClientAddress setResponse(ClientRequest response) {
   public InetSocketAddress getClientAddress() {
     return clientAddress;
   }
-
+  
+  /**
+   * Returns listening address of the server that received this packet.
+   * May be null if not set while creating the object of this class or child class.
+   * @return
+   */
+  public InetSocketAddress getServerListeningAddress()
+  {
+	  return this.serverListeningAddress;
+  }
 }

--- a/src/edu/umass/cs/gnsserver/gnsapp/selectpolicy/AbstractSelectPolicy.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/selectpolicy/AbstractSelectPolicy.java
@@ -1,0 +1,115 @@
+package edu.umass.cs.gnsserver.gnsapp.selectpolicy;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+
+import edu.umass.cs.gnscommon.packets.CommandPacket;
+import edu.umass.cs.gnsserver.gnsapp.GNSApplicationInterface;
+import edu.umass.cs.gnsserver.gnsapp.packet.SelectRequestPacket;
+import edu.umass.cs.gnsserver.gnsapp.packet.SelectResponsePacket;
+
+
+/**
+ * This class is an abstract class for specifying a select policy.
+ * 
+ * The object of this class is created based on Java reflection, 
+ * by taking the class name as input from the GNS config files. 
+ * The child class must implement a constructor that takes {@link GNSApplicationInterface}
+ * as input. This class also has a cyclic dependency with {@link GNSApp} but that is needed
+ * to perform signature checking for select requests. 
+ * 
+ * @author ayadav
+ */
+public abstract class AbstractSelectPolicy
+{
+	protected static final Logger LOG = Logger.getLogger(AbstractSelectPolicy.class.getName());
+	
+	protected final GNSApplicationInterface<String> gnsApp;
+	
+	public AbstractSelectPolicy(GNSApplicationInterface<String> gnsApp)
+	{
+		this.gnsApp = gnsApp;
+	}
+	
+	/**
+	 * This method processes a select request from a client in a non-blocking manner.
+	 * 
+	 * One thing to note is that this method doesn't need to be blocking. 
+	 * The code chain for this method is as follows. The gigapaxos calls {@link GNSApp#execute}
+	 * method, in the COMMAND case, if the command is a select command then we call this method. 
+	 * If the command is not a select command then we process as usual in the 
+	 * {@link GNSApp#execute}.
+	 * 
+	 * The  {@link GNSApp#execute} method doesn't need to block for the completion of a
+	 * SelectRequest, i.e., {@link GNSApp#execute} calls 
+	 * {@link #handleSelectRequestFromClient(CommandPacket)} method and 
+	 * this method forwards the select request to the  required NSs and returns.
+	 * 
+	 * 
+	 * @param request, the incoming request
+	 * @return Returns {@link Future}, which the caller of 
+	 * {@link #handleSelectRequestFromClient(CommandPacket)} can use 
+	 * to wait for the completion. 
+	 */
+	public abstract Future<Boolean> handleSelectRequestFromClient(CommandPacket request);
+	
+	
+	/**
+	 * This method is called in the SELECT_REQUEST case of {@link GNSApp#execute}
+	 * This method is called on NSs that process a select request and return GUIDs  
+	 * to the select request's originating NS. 
+	 * 
+	 * This method performs DB operations but it is not blocking. For improving the 
+	 * performance we can perform DB operations in a separate thread pool, so that
+	 * the gigapaxos or NIO threads, which are small in number, don't block for
+	 * DB operations.  
+	 * 
+	 * 
+	 * @param selectReq
+	 */
+	public abstract void handleSelectRequestAtNS(SelectRequestPacket selectReq);
+	
+	
+	/**
+	 * This method is called at a select request originating NS when another NS
+	 * replies back for an earlier select request. 
+	 * In this method, we aggregate the response GUIDs and if all the contacted NSs have 
+	 * responded then we send a reply back to the client. 
+	 * 
+	 * 
+	 * @param selectResp
+	 */
+	public abstract void handleSelectResponseFromNS(SelectResponsePacket selectResp); 
+	
+	
+	/**
+	 * Creates the object of clazz by reflection. 
+	 * clazz will be a child class of {@link AbstractSelectPolicy} whose 
+	 * class path will be specified in the GNS config files.
+	 * 
+	 * @param clazz
+	 * @param gnsApp
+	 * @return null if the object creation fails.
+	 */
+	public static AbstractSelectPolicy createSelectObject(Class<?> clazz, 
+											GNSApplicationInterface<?> gnsApp) 
+	{
+		try
+		{
+			return (AbstractSelectPolicy) clazz.getConstructor
+					(GNSApplicationInterface.class).newInstance(gnsApp);
+		} 
+		catch (InstantiationException | IllegalAccessException
+				| IllegalArgumentException | InvocationTargetException
+				| NoSuchMethodException | SecurityException e) 
+		{
+			LOG.log(Level.SEVERE, 
+					e.getClass().getSimpleName() + " while creating " + clazz);
+			e.printStackTrace();
+		}
+		return null;
+	}
+}

--- a/src/edu/umass/cs/gnsserver/main/GNSConfig.java
+++ b/src/edu/umass/cs/gnsserver/main/GNSConfig.java
@@ -254,7 +254,21 @@ public class GNSConfig {
      * The class name to use for doing sanity checks while updating GNS
      * record. Must extend {@link edu.umass.cs.gnsserver.extensions.sanitycheck.AbstractSanityCheck}
      */
-    SANITY_CHECKER(NullSanityCheck.class.getName())
+    SANITY_CHECKER(NullSanityCheck.class.getName()),
+    
+    
+    /** If the flag is true then a custom select implementation is used.
+     * If it is false the blocking {@link edu.umass.cs.gnsserver.gnsapp.Select} 
+     * is used.
+     */
+    ENABLE_CUSTOM_SELECT(false),
+     
+     /**
+      * Specifies the select policy type.
+      * This policy is only used when {@link #ENABLE_CUSTOM_SELECT} is true.
+      */
+     SELECT_POLICY(""),
+     
     ;
 
     final Object defaultValue;


### PR DESCRIPTION
Added support for the configurable select policy. There are some minor changes in other parts of the code, so that a custom select policy can use the existing methods in the gnsapp.Select class and some other classes. There are also some changes to retrieve the client and server addresses for  select requests. 