### PR TITLE
Added the support to set the maximum outstanding request in the GNSClient.

### DIFF
--- a/src/edu/umass/cs/gnsclient/client/GNSClient.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSClient.java
@@ -597,6 +597,17 @@ public class GNSClient {
 				throws RequestParseException {
 			return GNSAppUtil.getRequestStatic(bytes, header, unstringer);
 		}
+		
+		/**
+		 * Sets the maximum outstanding app requests in the {@link GNSClient},
+		 * which internally sets the maximum outstanding app requests in 
+		 * {@link ReconfigurableAppClientAsync}
+		 * @param n The maximum number of outstanding app requests to allow.
+		 */
+		public void setMaximumOutstandingAppRequests(int n)
+		{
+			ReconfigurableAppClientAsync.setMaxOutstandingAppRequests(n);
+		}
 	} // End of AsyncClient
 
 	/**
@@ -613,6 +624,17 @@ public class GNSClient {
 	 */
 	public void setGNSProxy(InetSocketAddress LNS) {
 		this.GNSProxy = LNS;
+	}
+	
+	/**
+	 * Sets the maximum outstanding app requests in the {@link GNSClient},
+	 * which internally sets the maximum outstanding app requests in 
+	 * {@link ReconfigurableAppClientAsync}
+	 * @param n The maximum number of outstanding app requests to allow.
+	 */
+	public void setMaximumOutstandingAppRequests(int n)
+	{
+		asyncClient.setMaximumOutstandingAppRequests(n);
 	}
 
 	private long forcedTimeout = 0;


### PR DESCRIPTION
The support to configure maximum outstanding requests is needed for the capacity measurement experiments. 