### PR TITLE
GNSClientCommand changes

### DIFF
--- a/src/edu/umass/cs/contextservice/integration/examples/ContextServiceExample.java
+++ b/src/edu/umass/cs/contextservice/integration/examples/ContextServiceExample.java
@@ -5,7 +5,8 @@ import org.json.JSONObject;
 
 import edu.umass.cs.contextservice.client.ContextServiceClient;
 import edu.umass.cs.contextservice.config.ContextServiceConfig.PrivacySchemes;
-import edu.umass.cs.gnsclient.client.GNSClientCommands;
+import edu.umass.cs.gnsclient.client.GNSClient;
+import edu.umass.cs.gnsclient.client.GNSCommand;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
 
@@ -68,7 +69,7 @@ public class ContextServiceExample {
   /**
    *
    */
-  public static GNSClientCommands client;
+  public static GNSClient client;
 
   /**
    *
@@ -89,7 +90,7 @@ public class ContextServiceExample {
     String csHost = args[0];
     int csPort = Integer.parseInt(args[1]);
 
-    client = new GNSClientCommands();
+    client = new GNSClient();
     System.out.println("[Client connected to GNS]\n");
 
     try {
@@ -140,7 +141,7 @@ public class ContextServiceExample {
             + " entering the geofence specified in the search query by doing an update"
             + ", latitude=32.5 and longitude=-97.5, in GNS\n");
 
-    client.update(account_guid, userJSON);
+    client.execute(GNSCommand.update(account_guid, userJSON));
 
     // checking for trigger from context service that a new guid is added in an
     // already existing group. This call blocks until there are non zero triggers.
@@ -160,7 +161,8 @@ public class ContextServiceExample {
 
     System.out.println("\n A user with guid" + account_guid.getGuid()
             + " going out of the geofence specified in the search query by doing an update, latitude=31 and longitude=-97.5,  in GNS\n");
-    client.update(account_guid, userJSON);
+    
+    client.execute(GNSCommand.update(account_guid, userJSON));
 
     // checking for trigger from context service that the guid is removed from an
     // already existing group. This call blocks until there are non zero triggers.

--- a/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
@@ -40,33 +40,29 @@ import edu.umass.cs.gnscommon.GNSProtocol;
 import java.util.List;
 
 /**
- *
- * A simple-to-use client that uses uses {@link GNSClient} and
+ * A simple-to-use class for executing GNS commands, 
+ * which internally uses {@link GNSClient} and
  * {@link GNSCommand} to communicate with a GNS instance over TCP.
  * Used for sending synchronous client requests to the GNS server.
  * If you want an asynchronous client see the above classes.
  *
- * @author westy
+ * @author westy, ayadav
  */
-public class GNSClientCommands extends GNSClient {
-
-  /**
-   * @throws IOException
-   */
-  public GNSClientCommands() throws IOException {
-    super((InetSocketAddress) null);
-  }
-
-  /**
-   * Creates a new {@link GNSClient} object
-   *
-   * @param anyReconfigurator
-   * @throws java.io.IOException
-   */
-  public GNSClientCommands(InetSocketAddress anyReconfigurator)
-          throws IOException {
-    super(anyReconfigurator);
-  }
+public class GNSClientCommands 
+{
+	private GNSClient gnsClient;
+	
+	/**
+	 * Creates the object for this class that uses 
+	 * gnsClient supplied in the constructor to execute 
+	 * GNS commands.
+	 * 
+	 * @param gnsClient
+	 */
+	public GNSClientCommands(GNSClient gnsClient)
+	{
+		this.gnsClient = gnsClient;
+	}
 
   // READ AND WRITE COMMANDS
   /**
@@ -83,7 +79,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void update(String targetGuid, JSONObject json, GuidEntry writer)
           throws IOException, ClientException {
-    execute(GNSCommand.update(targetGuid, json, writer));
+    gnsClient.execute(GNSCommand.update(targetGuid, json, writer));
   }
 
   /**
@@ -119,7 +115,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldUpdate(String targetGuid, String field, Object value,
           GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldUpdate(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldUpdate(targetGuid, field, value, writer));
   }
 
   /**
@@ -153,7 +149,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldCreateIndex(GuidEntry guid, String field, String index)
           throws IOException, ClientException {
-    execute(GNSCommand.fieldCreateIndex(guid, field, index));
+    gnsClient.execute(GNSCommand.fieldCreateIndex(guid, field, index));
   }
 
   /**
@@ -172,7 +168,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONObject read(String targetGuid, GuidEntry reader)
           throws ClientException, IOException {
-    return execute(GNSCommand.read(targetGuid, reader)).getResultJSONObject();
+    return gnsClient.execute(GNSCommand.read(targetGuid, reader)).getResultJSONObject();
   }
 
   /**
@@ -189,7 +185,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONObject readSecure(String targetGuid)
           throws ClientException, IOException {
-    return execute(GNSCommand.readSecure(targetGuid)).getResultJSONObject();
+    return gnsClient.execute(GNSCommand.readSecure(targetGuid)).getResultJSONObject();
   }
 
   /**
@@ -226,7 +222,7 @@ public class GNSClientCommands extends GNSClient {
   public boolean fieldExists(String targetGuid, String field, GuidEntry reader)
           throws ClientException, IOException {
     try {
-      execute(GNSCommand.fieldExists(targetGuid, field, reader));
+      gnsClient.execute(GNSCommand.fieldExists(targetGuid, field, reader));
       return true;
     } catch (ClientException | IOException e) {
       return false;
@@ -271,7 +267,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public String fieldRead(String targetGuid, String field, GuidEntry reader)
           throws ClientException, IOException {
-    JSONObject result = execute(GNSCommand.fieldRead(targetGuid, field, reader)).getResultJSONObject();
+    JSONObject result = gnsClient.execute(GNSCommand.fieldRead(targetGuid, field, reader)).getResultJSONObject();
     if (GNSProtocol.ENTIRE_RECORD.toString().equals(field)) {
       return result.toString();
     } else {
@@ -319,7 +315,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public String fieldRead(String targetGuid, ArrayList<String> fields,
           GuidEntry reader) throws ClientException, IOException {
-    return execute(GNSCommand.fieldRead(targetGuid, fields, reader)).getResultString();
+    return gnsClient.execute(GNSCommand.fieldRead(targetGuid, fields, reader)).getResultString();
   }
 
   /**
@@ -355,7 +351,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldRemove(String targetGuid, String field, GuidEntry writer)
           throws IOException, ClientException {
-    execute(GNSCommand.fieldRemove(targetGuid, field, writer));
+    gnsClient.execute(GNSCommand.fieldRemove(targetGuid, field, writer));
   }
 
   // SELECT COMMANDS
@@ -384,7 +380,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray selectQuery(String query) throws ClientException, IOException {
-    return execute(GNSCommand.selectQuery(query)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectQuery(query)).getResultJSONArray();
   }
 
   /**
@@ -413,7 +409,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray selectQuery(GuidEntry reader, String query) throws ClientException, IOException {
-    return execute(GNSCommand.selectQuery(reader, query)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectQuery(reader, query)).getResultJSONArray();
   }
   
   /**
@@ -446,7 +442,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray selectRecords(String query, List<String> fields) throws ClientException, IOException {
-    return execute(GNSCommand.selectRecords(query, fields)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectRecords(query, fields)).getResultJSONArray();
   }
 
   /**
@@ -478,7 +474,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray selectRecords(GuidEntry reader, String query, List<String> fields) throws ClientException, IOException {
-    return execute(GNSCommand.selectRecords(reader, query, fields)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectRecords(reader, query, fields)).getResultJSONArray();
   }
 
   /**
@@ -506,7 +502,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray selectSetupGroupQuery(GuidEntry accountGuid,
           String publicKey, String query, int interval) throws ClientException, IOException {
-    return execute(GNSCommand.selectSetupGroupQuery(accountGuid, publicKey, query, interval)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectSetupGroupQuery(accountGuid, publicKey, query, interval)).getResultJSONArray();
   }
 
   /**
@@ -535,7 +531,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray selectSetupGroupQuery(GuidEntry reader, GuidEntry accountGuid,
           String publicKey, String query, int interval) throws ClientException, IOException {
-    return execute(GNSCommand.selectSetupGroupQuery(reader, accountGuid, publicKey,
+    return gnsClient.execute(GNSCommand.selectSetupGroupQuery(reader, accountGuid, publicKey,
             query, interval)).getResultJSONArray();
   }
 
@@ -553,7 +549,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray selectLookupGroupQuery(String guid) throws ClientException, IOException {
-    return execute(GNSCommand.selectLookupGroupQuery(guid)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectLookupGroupQuery(guid)).getResultJSONArray();
   }
   
   /**
@@ -571,7 +567,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray selectLookupGroupQuery(GuidEntry reader, String guid) throws ClientException, IOException {
-    return execute(GNSCommand.selectLookupGroupQuery(reader, guid)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectLookupGroupQuery(reader, guid)).getResultJSONArray();
   }
 
   // ACCOUNT COMMANDS
@@ -586,7 +582,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public String lookupGuid(String alias) throws IOException, ClientException {
-    return execute(GNSCommand.lookupGUID(alias)).getResultString();
+    return gnsClient.execute(GNSCommand.lookupGUID(alias)).getResultString();
   }
 
   /**
@@ -601,7 +597,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public String lookupPrimaryGuid(String guid)
           throws IOException, ClientException {
-    return execute(GNSCommand.lookupPrimaryGUID(guid)).getResultString();
+    return gnsClient.execute(GNSCommand.lookupPrimaryGUID(guid)).getResultString();
   }
 
   /**
@@ -618,7 +614,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONObject lookupGuidRecord(String guid) throws IOException,
           ClientException {
-    return execute(GNSCommand.lookupGUIDRecord(guid)).getResultJSONObject();
+    return gnsClient.execute(GNSCommand.lookupGUIDRecord(guid)).getResultJSONObject();
   }
 
   /**
@@ -637,7 +633,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONObject lookupAccountRecord(String accountGuid)
           throws IOException, ClientException {
-    return execute(GNSCommand.lookupAccountRecord(accountGuid)).getResultJSONObject();
+    return gnsClient.execute(GNSCommand.lookupAccountRecord(accountGuid)).getResultJSONObject();
   }
 
   /**
@@ -702,7 +698,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public GuidEntry accountGuidCreate(String alias, String password) throws ClientException, IOException {
     try {
-      execute(GNSCommand.createAccount(alias, password));
+      gnsClient.execute(GNSCommand.createAccount(alias, password));
     } catch (NoSuchAlgorithmException e) {
       throw new ClientException(e);
     }
@@ -733,7 +729,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public GuidEntry accountGuidCreateSecure(String alias, String password) throws ClientException, IOException {
     try {
-      execute(GNSCommand.createAccountSecure(alias, password));
+      gnsClient.execute(GNSCommand.createAccountSecure(alias, password));
     } catch (NoSuchAlgorithmException e) {
       throw new ClientException(e);
     }
@@ -760,7 +756,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public String accountGuidVerify(GuidEntry guid, String code) throws ClientException, IOException {
-    return execute(GNSCommand.accountGuidVerify(guid, code)).getResultString();
+    return gnsClient.execute(GNSCommand.accountGuidVerify(guid, code)).getResultString();
   }
 
   /**
@@ -774,7 +770,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public String accountResendAuthenticationEmail(GuidEntry guid) throws ClientException, IOException {
-    return execute(GNSCommand.accountResendAuthenticationEmail(guid)).getResultString();
+    return gnsClient.execute(GNSCommand.accountResendAuthenticationEmail(guid)).getResultString();
   }
 
   /**
@@ -787,7 +783,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public void accountGuidRemove(GuidEntry guid) throws ClientException, IOException {
-    execute(GNSCommand.accountGuidRemove(guid)).getResultString();
+    gnsClient.execute(GNSCommand.accountGuidRemove(guid)).getResultString();
   }
 
   /**
@@ -803,7 +799,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void accountGuidRemoveSecure(String name)
           throws ClientException, IOException {
-    execute(GNSCommand.accountGuidRemoveSecure(name));
+    gnsClient.execute(GNSCommand.accountGuidRemoveSecure(name));
   }
 
   /**
@@ -818,7 +814,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void accountGuidRemoveWithPassword(String name, String password)
           throws ClientException, IOException {
-    execute(GNSCommand.accountGuidRemoveWithPassword(name, password));
+    gnsClient.execute(GNSCommand.accountGuidRemoveWithPassword(name, password));
   }
 
   /**
@@ -835,7 +831,7 @@ public class GNSClientCommands extends GNSClient {
   public GuidEntry guidCreate(GuidEntry accountGuid, String alias)
           throws ClientException, IOException {
 
-    execute(GNSCommand.guidCreate(accountGuid, alias));
+    gnsClient.execute(GNSCommand.guidCreate(accountGuid, alias));
     GuidEntry guidEntry = GuidUtils.lookupGuidEntryFromDatabase(this, alias);
     // If something went wrong an exception should be thrown above, but we're checking
     // here anyway just to be safe.
@@ -861,7 +857,7 @@ public class GNSClientCommands extends GNSClient {
   public GuidEntry guidCreateKeyless(GuidEntry accountGuid, String alias)
           throws ClientException, IOException {
 
-    execute(GNSCommand.guidCreateKeyless(accountGuid, alias));
+    gnsClient.execute(GNSCommand.guidCreateKeyless(accountGuid, alias));
     GuidEntry guidEntry = GuidUtils.lookupGuidEntryFromDatabase(this, alias);
     // If something went wrong an exception should be thrown above, but we're checking
     // here anyway just to be safe.
@@ -883,7 +879,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void guidBatchCreate(GuidEntry accountGuid, Set<String> aliases)
           throws ClientException, IOException {
-    execute(GNSCommand.batchCreateGUIDs(accountGuid, aliases));
+    gnsClient.execute(GNSCommand.batchCreateGUIDs(accountGuid, aliases));
   }
 
   /**
@@ -897,7 +893,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void guidBatchCreate(GuidEntry accountGuid, Set<String> aliases, long timeout)
           throws ClientException, IOException {
-    execute(GNSCommand.batchCreateGUIDs(accountGuid, aliases), timeout);
+    gnsClient.execute(GNSCommand.batchCreateGUIDs(accountGuid, aliases), timeout);
   }
 
   /**
@@ -911,7 +907,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public void guidRemove(GuidEntry guid) throws ClientException, IOException {
-    execute(GNSCommand.guidRemove(guid));
+    gnsClient.execute(GNSCommand.guidRemove(guid));
   }
 
   /**
@@ -926,7 +922,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void guidRemove(GuidEntry accountGuid, String guidToRemove)
           throws ClientException, IOException {
-    execute(GNSCommand.guidRemove(accountGuid, guidToRemove));
+    gnsClient.execute(GNSCommand.guidRemove(accountGuid, guidToRemove));
   }
 
   // GROUP COMMANDS
@@ -947,7 +943,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray groupGetMembers(String groupGuid, GuidEntry reader)
           throws ClientException, IOException {
-    return execute(GNSCommand.groupGetMembers(groupGuid, reader)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.groupGetMembers(groupGuid, reader)).getResultJSONArray();
   }
 
   /**
@@ -966,7 +962,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray guidGetGroups(String guid, GuidEntry reader)
           throws IOException, ClientException {
-    return execute(GNSCommand.guidGetGroups(guid, reader)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.guidGetGroups(guid, reader)).getResultJSONArray();
   }
 
   /**
@@ -987,7 +983,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void groupAddGuid(String groupGuid, String guidToAdd,
           GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.groupAddGuid(groupGuid, guidToAdd, writer));
+    gnsClient.execute(GNSCommand.groupAddGuid(groupGuid, guidToAdd, writer));
   }
 
   /**
@@ -1006,7 +1002,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void groupAddGuids(String groupGuid, JSONArray members,
           GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.groupAddGUIDs(groupGuid, members, writer));
+    gnsClient.execute(GNSCommand.groupAddGUIDs(groupGuid, members, writer));
   }
 
   /**
@@ -1025,7 +1021,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void groupRemoveGuid(String groupGuid, String guidToRemove,
           GuidEntry writer) throws ClientException, IOException {
-    execute(GNSCommand.groupRemoveGuid(groupGuid, guidToRemove, writer));
+    gnsClient.execute(GNSCommand.groupRemoveGuid(groupGuid, guidToRemove, writer));
   }
 
   /**
@@ -1044,7 +1040,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void groupRemoveGuids(String groupGuid, JSONArray members,
           GuidEntry writer) throws ClientException, IOException {
-    execute(GNSCommand.groupRemoveGuids(groupGuid, members, writer));
+    gnsClient.execute(GNSCommand.groupRemoveGuids(groupGuid, members, writer));
   }
 
   /**
@@ -1066,7 +1062,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void groupAddMembershipUpdatePermission(GuidEntry groupGuid,
           String guidToAuthorize) throws ClientException, IOException {
-    execute(GNSCommand.groupAddMembershipUpdatePermission(groupGuid, guidToAuthorize));
+    gnsClient.execute(GNSCommand.groupAddMembershipUpdatePermission(groupGuid, guidToAuthorize));
   }
 
   /**
@@ -1088,7 +1084,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void groupRemoveMembershipUpdatePermission(GuidEntry groupGuid,
           String guidToUnauthorize) throws ClientException, IOException {
-    execute(GNSCommand.groupRemoveMembershipUpdatePermission(groupGuid, guidToUnauthorize));
+    gnsClient.execute(GNSCommand.groupRemoveMembershipUpdatePermission(groupGuid, guidToUnauthorize));
   }
 
   /**
@@ -1110,7 +1106,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void groupAddMembershipReadPermission(GuidEntry groupGuid,
           String guidToAuthorize) throws ClientException, IOException {
-    execute(GNSCommand.groupAddMembershipReadPermission(groupGuid, guidToAuthorize));
+    gnsClient.execute(GNSCommand.groupAddMembershipReadPermission(groupGuid, guidToAuthorize));
   }
 
   /**
@@ -1132,7 +1128,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void groupRemoveMembershipReadPermission(GuidEntry groupGuid,
           String guidToUnauthorize) throws ClientException, IOException {
-    execute(GNSCommand.groupRemoveMembershipReadPermission(groupGuid, guidToUnauthorize));
+    gnsClient.execute(GNSCommand.groupRemoveMembershipReadPermission(groupGuid, guidToUnauthorize));
   }
 
   // ACL COMMANDS
@@ -1158,7 +1154,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void aclAdd(AclAccessType accessType, GuidEntry targetGuid,
           String field, String accesserGuid) throws ClientException, IOException {
-    execute(GNSCommand.aclAdd(accessType, targetGuid, field, accesserGuid));
+    gnsClient.execute(GNSCommand.aclAdd(accessType, targetGuid, field, accesserGuid));
   }
 
   /**
@@ -1180,7 +1176,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void aclRemove(AclAccessType accessType, GuidEntry targetGuid,
           String field, String accesserGuid) throws ClientException, IOException {
-    execute(GNSCommand.aclRemove(accessType, targetGuid, field, accesserGuid));
+    gnsClient.execute(GNSCommand.aclRemove(accessType, targetGuid, field, accesserGuid));
   }
 
   /**
@@ -1203,7 +1199,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray aclGet(AclAccessType accessType, GuidEntry targetGuid,
           String field, String readerGuid) throws ClientException, IOException {
-    return execute(GNSCommand.aclGet(accessType, targetGuid, field, readerGuid)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.aclGet(accessType, targetGuid, field, readerGuid)).getResultJSONArray();
   }
 
   /**
@@ -1229,7 +1225,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void aclAddSecure(AclAccessType accessType, String targetGuid,
           String field, String accesserGuid) throws ClientException, IOException {
-    execute(GNSCommand.aclAddSecure(accessType, targetGuid, field, accesserGuid));
+    gnsClient.execute(GNSCommand.aclAddSecure(accessType, targetGuid, field, accesserGuid));
   }
 
   /**
@@ -1252,7 +1248,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void aclRemoveSecure(AclAccessType accessType, String targetGuid,
           String field, String accesserGuid) throws ClientException, IOException {
-    execute(GNSCommand.aclRemoveSecure(accessType, targetGuid, field, accesserGuid));
+    gnsClient.execute(GNSCommand.aclRemoveSecure(accessType, targetGuid, field, accesserGuid));
   }
 
   /**
@@ -1274,7 +1270,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray aclGetSecure(AclAccessType accessType, String targetGuid,
           String field) throws ClientException, IOException {
-    return execute(GNSCommand.aclGetSecure(accessType, targetGuid, field)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.aclGetSecure(accessType, targetGuid, field)).getResultJSONArray();
   }
 
   /**
@@ -1292,7 +1288,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldCreateAcl(AclAccessType accessType, GuidEntry guid, String field,
           String writerGuid) throws ClientException, IOException {
-    execute(GNSCommand.fieldCreateAcl(accessType, guid, field, writerGuid));
+    gnsClient.execute(GNSCommand.fieldCreateAcl(accessType, guid, field, writerGuid));
   }
 
   /**
@@ -1325,7 +1321,7 @@ public class GNSClientCommands extends GNSClient {
   public void fieldDeleteAcl(AclAccessType accessType, GuidEntry guid, String field,
           String writerGuid)
           throws ClientException, IOException {
-    execute(GNSCommand.fieldDeleteAcl(accessType, guid, field, writerGuid));
+    gnsClient.execute(GNSCommand.fieldDeleteAcl(accessType, guid, field, writerGuid));
   }
 
   /**
@@ -1357,7 +1353,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public boolean fieldAclExists(AclAccessType accessType, GuidEntry guid, String field,
           String readerGuid) throws ClientException, IOException {
-    return execute(GNSCommand.fieldAclExists(accessType, guid, field, readerGuid)).getResultBoolean();
+    return gnsClient.execute(GNSCommand.fieldAclExists(accessType, guid, field, readerGuid)).getResultBoolean();
   }
 
   /**
@@ -1390,7 +1386,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public void addAlias(GuidEntry guid, String name) throws ClientException, IOException {
-    execute(GNSCommand.addAlias(guid, name));
+    gnsClient.execute(GNSCommand.addAlias(guid, name));
   }
 
   /**
@@ -1405,7 +1401,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public void removeAlias(GuidEntry guid, String name) throws ClientException, IOException {
-    execute(GNSCommand.removeAlias(guid, name));
+    gnsClient.execute(GNSCommand.removeAlias(guid, name));
   }
 
   /**
@@ -1419,7 +1415,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray getAliases(GuidEntry guid) throws ClientException, IOException {
-    return execute(GNSCommand.getAliases(guid)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.getAliases(guid)).getResultJSONArray();
   }
 
   // Extended commands
@@ -1439,7 +1435,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldCreateList(String targetGuid, String field,
           JSONArray value, GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldCreateList(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldCreateList(targetGuid, field, value, writer));
   }
 
   /**
@@ -1457,7 +1453,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldAppendOrCreateList(String targetGuid, String field,
           JSONArray value, GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldAppendOrCreateList(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldAppendOrCreateList(targetGuid, field, value, writer));
   }
 
   /**
@@ -1475,7 +1471,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldReplaceOrCreateList(String targetGuid, String field,
           JSONArray value, GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldReplaceOrCreateList(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldReplaceOrCreateList(targetGuid, field, value, writer));
   }
 
   /**
@@ -1496,7 +1492,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldAppend(String targetGuid, String field, JSONArray value,
           GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldAppend(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldAppend(targetGuid, field, value, writer));
   }
 
   /**
@@ -1518,7 +1514,7 @@ public class GNSClientCommands extends GNSClient {
   public void fieldReplaceList(String targetGuid, String field,
           JSONArray value, GuidEntry writer) throws IOException,
           ClientException {
-    execute(GNSCommand.fieldReplaceList(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldReplaceList(targetGuid, field, value, writer));
   }
 
   /**
@@ -1539,7 +1535,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldClear(String targetGuid, String field, JSONArray value,
           GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldClear(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldClear(targetGuid, field, value, writer));
   }
 
   /**
@@ -1558,7 +1554,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldClear(String targetGuid, String field, GuidEntry writer)
           throws IOException, ClientException {
-    execute(GNSCommand.fieldClear(targetGuid, field, writer));
+    gnsClient.execute(GNSCommand.fieldClear(targetGuid, field, writer));
   }
 
   /**
@@ -1580,7 +1576,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray fieldReadArray(String guid, String field, GuidEntry reader)
           throws ClientException, IOException {
-    String response = execute(GNSCommand.fieldReadArray(guid, field, reader)).getResultString();
+    String response = gnsClient.execute(GNSCommand.fieldReadArray(guid, field, reader)).getResultString();
     try {
       return CommandUtils.commandResponseToJSONArray(field, response);
     } catch (JSONException e) {
@@ -1606,7 +1602,7 @@ public class GNSClientCommands extends GNSClient {
   public void fieldSetElement(String targetGuid, String field,
           String newValue, int index, GuidEntry writer) throws IOException,
           ClientException {
-    execute(GNSCommand.fieldSetElement(targetGuid, field, newValue, index, writer));
+    gnsClient.execute(GNSCommand.fieldSetElement(targetGuid, field, newValue, index, writer));
   }
 
   /**
@@ -1623,7 +1619,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldSetNull(String targetGuid, String field, GuidEntry writer)
           throws IOException, ClientException {
-    execute(GNSCommand.fieldSetNull(targetGuid, field, writer));
+    gnsClient.execute(GNSCommand.fieldSetNull(targetGuid, field, writer));
   }
 
   //
@@ -1642,7 +1638,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray select(String field, String value) throws ClientException, IOException {
-    return execute(GNSCommand.select(field, value)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.select(field, value)).getResultJSONArray();
   }
   
   /**
@@ -1659,7 +1655,7 @@ public class GNSClientCommands extends GNSClient {
    * if a communication error occurs
    */
   public JSONArray select(GuidEntry reader, String field, String value) throws ClientException, IOException {
-    return execute(GNSCommand.select(reader, field, value)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.select(reader, field, value)).getResultJSONArray();
   }
   
   /**
@@ -1680,7 +1676,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray selectWithin(String field, JSONArray value)
           throws ClientException, IOException {
-    return execute(GNSCommand.selectWithin(field, value)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectWithin(field, value)).getResultJSONArray();
   }
   
   /**
@@ -1701,7 +1697,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray selectWithin(GuidEntry reader, String field, JSONArray value)
           throws ClientException, IOException {
-    return execute(GNSCommand.selectWithin(reader, field, value)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectWithin(reader, field, value)).getResultJSONArray();
   }
 
   /**
@@ -1723,7 +1719,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray selectNear(String field, JSONArray value,
           Double maxDistance) throws ClientException, IOException {
-    return execute(GNSCommand.selectNear(field, value, maxDistance)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectNear(field, value, maxDistance)).getResultJSONArray();
   }
   
   /**
@@ -1745,7 +1741,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public JSONArray selectNear(GuidEntry reader, String field, JSONArray value,
           Double maxDistance) throws ClientException, IOException {
-    return execute(GNSCommand.selectNear(reader, field, value, maxDistance)).getResultJSONArray();
+    return gnsClient.execute(GNSCommand.selectNear(reader, field, value, maxDistance)).getResultJSONArray();
   }
 
   /**
@@ -1803,7 +1799,7 @@ public class GNSClientCommands extends GNSClient {
   public JSONArray getLocation(String targetGuid, GuidEntry readerGuid)
           throws ClientException, IOException {
     try {
-      JSONObject json = execute(GNSCommand.getLocation(targetGuid, readerGuid)).getResultJSONObject();
+      JSONObject json = gnsClient.execute(GNSCommand.getLocation(targetGuid, readerGuid)).getResultJSONObject();
       return json.getJSONArray(GNSProtocol.LOCATION_FIELD_NAME.toString());
     } catch (JSONException e) {
       throw new ClientException(e);
@@ -1836,7 +1832,7 @@ public class GNSClientCommands extends GNSClient {
   // Active Code
   public void activeCodeClear(String guid, String action, GuidEntry writerGuid)
           throws ClientException, IOException {
-    execute(GNSCommand.activeCodeClear(guid, action, writerGuid));
+    gnsClient.execute(GNSCommand.activeCodeClear(guid, action, writerGuid));
   }
 
   /**
@@ -1852,7 +1848,7 @@ public class GNSClientCommands extends GNSClient {
   public void activeCodeSet(String guid, String action, String code,
           GuidEntry writerGuid) throws ClientException, IOException {
     // The GNSCommand method expects bytes which it Base64 encodes.
-    execute(GNSCommand.activeCodeSet(guid, action, code, writerGuid));
+    gnsClient.execute(GNSCommand.activeCodeSet(guid, action, code, writerGuid));
   }
 
   /**
@@ -1867,7 +1863,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public String activeCodeGet(String guid, String action, GuidEntry readerGuid)
           throws ClientException, IOException {
-    return execute(GNSCommand.activeCodeGet(guid, action, readerGuid)).getResultString();
+    return gnsClient.execute(GNSCommand.activeCodeGet(guid, action, readerGuid)).getResultString();
   }
 
   // Extended commands
@@ -1884,7 +1880,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldCreateList(GuidEntry target, String field, JSONArray value)
           throws IOException, ClientException {
-    execute(GNSCommand.fieldCreateList(field, field, value, target));
+    gnsClient.execute(GNSCommand.fieldCreateList(field, field, value, target));
   }
 
   /**
@@ -1903,7 +1899,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldCreateOneElementList(String targetGuid, String field,
           String value, GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldCreateOneElementList(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldCreateOneElementList(targetGuid, field, value, writer));
   }
 
   /**
@@ -1939,7 +1935,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldAppendOrCreate(String targetGuid, String field,
           String value, GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldAppendOrCreate(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldAppendOrCreate(targetGuid, field, value, writer));
   }
 
   /**
@@ -1959,7 +1955,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldReplaceOrCreate(String targetGuid, String field,
           String value, GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldReplaceOrCreate(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldReplaceOrCreate(targetGuid, field, value, writer));
   }
 
   /**
@@ -2015,7 +2011,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldReplace(String targetGuid, String field, String value,
           GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldReplace(writer, field, value));
+    gnsClient.execute(GNSCommand.fieldReplace(writer, field, value));
   }
 
   /**
@@ -2065,7 +2061,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldAppend(String targetGuid, String field, String value,
           GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldAppend(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldAppend(targetGuid, field, value, writer));
   }
 
   /**
@@ -2101,7 +2097,7 @@ public class GNSClientCommands extends GNSClient {
   public void fieldAppendWithSetSemantics(String targetGuid, String field,
           JSONArray value, GuidEntry writer) throws IOException,
           ClientException {
-    execute(GNSCommand.fieldAppendWithSetSemantics(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldAppendWithSetSemantics(targetGuid, field, value, writer));
   }
 
   /**
@@ -2137,7 +2133,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldAppendWithSetSemantics(String targetGuid, String field,
           String value, GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldAppendWithSetSemantics(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldAppendWithSetSemantics(targetGuid, field, value, writer));
   }
 
   /**
@@ -2172,7 +2168,7 @@ public class GNSClientCommands extends GNSClient {
   @Deprecated
   public void fieldReplaceFirstElement(String targetGuid, String field,
           String value, GuidEntry writer) throws IOException, ClientException {
-    execute(GNSCommand.fieldReplaceFirstElement(targetGuid, field, value, writer));
+    gnsClient.execute(GNSCommand.fieldReplaceFirstElement(targetGuid, field, value, writer));
   }
 
   /**
@@ -2213,7 +2209,7 @@ public class GNSClientCommands extends GNSClient {
   public void fieldSubstitute(String targetGuid, String field,
           String newValue, String oldValue, GuidEntry writer)
           throws IOException, ClientException {
-    execute(GNSCommand.fieldSubstitute(writer, field, newValue, oldValue));
+    gnsClient.execute(GNSCommand.fieldSubstitute(writer, field, newValue, oldValue));
   }
 
   /**
@@ -2258,7 +2254,7 @@ public class GNSClientCommands extends GNSClient {
   public void fieldSubstitute(String targetGuid, String field,
           JSONArray newValue, JSONArray oldValue, GuidEntry writer)
           throws IOException, ClientException {
-    execute(GNSCommand.fieldSubstitute(writer, field, newValue, oldValue));
+    gnsClient.execute(GNSCommand.fieldSubstitute(writer, field, newValue, oldValue));
   }
 
   /**
@@ -2300,7 +2296,7 @@ public class GNSClientCommands extends GNSClient {
   //FIXME: This should probably be deprecated and removed.
   public String fieldReadArrayFirstElement(String guid, String field,
           GuidEntry reader) throws ClientException, IOException {
-    return execute(GNSCommand.fieldReadArrayFirstElement(guid, field, reader)).getResultString();
+    return gnsClient.execute(GNSCommand.fieldReadArrayFirstElement(guid, field, reader)).getResultString();
   }
 
   /**
@@ -2335,7 +2331,7 @@ public class GNSClientCommands extends GNSClient {
    */
   public void fieldRemove(GuidEntry guid, String field)
           throws IOException, ClientException {
-    execute(GNSCommand.fieldRemove(field, field, guid));
+    gnsClient.execute(GNSCommand.fieldRemove(field, field, guid));
   }
 
   /**
@@ -2353,11 +2349,48 @@ public class GNSClientCommands extends GNSClient {
     } catch (DuplicateNameException dne) {
       //Do nothing if it already exists.
     }
-    return execute(GNSCommand.dump()).getResultString();
+    return gnsClient.execute(GNSCommand.dump()).getResultString();
   }
-
-  @Override
+  
+  public void setForceCoordinatedReads(boolean forceCoordinatedReads)
+  {
+	  gnsClient = gnsClient.setForceCoordinatedReads(forceCoordinatedReads);
+  }
+  
+  /**
+   * For documentation refer to {@link GNSClient#getGNSProvider()}
+   * @return
+   */
+  @Deprecated
+  public String getGNSProvider()
+  {
+	  return gnsClient.getGNSProvider();
+  }
+  
+  /**
+   * For documentation refer to {@link GNSClient#setGNSProxy(InetSocketAddress)}
+   * @param proxy
+   */
+  public void setGNSProxy(InetSocketAddress proxy)
+  {
+	  gnsClient.setGNSProxy(proxy);
+  }
+  
+  /**
+   * Returns the GNSClient used by the object of this class. 
+   * This method is used to support some legacy code.
+   * @return
+   */
+  public GNSClient getGNSClient()
+  {
+	  return this.gnsClient;
+  }
+  
+  /**
+   * Closes the underlying {@link GNSClient}
+   * This method is also used to support the legacy code.
+   */
   public void close() {
-    super.close();
+    gnsClient.close();
   }
 }

--- a/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
+++ b/src/edu/umass/cs/gnsclient/client/GNSClientCommands.java
@@ -2352,6 +2352,10 @@ public class GNSClientCommands
     return gnsClient.execute(GNSCommand.dump()).getResultString();
   }
   
+  /**
+   * For documentation refer to {@link GNSClient#setForceCoordinatedReads(boolean)}
+   * @param forceCoordinatedReads
+   */
   public void setForceCoordinatedReads(boolean forceCoordinatedReads)
   {
 	  gnsClient = gnsClient.setForceCoordinatedReads(forceCoordinatedReads);

--- a/src/edu/umass/cs/gnsclient/client/bugreports/BatchCreateOpsFail.java
+++ b/src/edu/umass/cs/gnsclient/client/bugreports/BatchCreateOpsFail.java
@@ -16,6 +16,7 @@ import org.junit.runner.notification.Failure;
 
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig;
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig.TC;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSClientConfig;
 import edu.umass.cs.gnsclient.client.testing.GNSTestingConfig.GNSTC;
@@ -71,7 +72,7 @@ public class BatchCreateOpsFail extends DefaultTest {
   private void setupClientsAndGuids() throws Exception {
     clients = new GNSClientCommands[numClients];
     for (int i = 0; i < numClients; i++) {
-      clients[i] = new GNSClientCommands();
+      clients[i] = new GNSClientCommands(new GNSClient());
     }
     String gnsInstance = clients[0].getGNSProvider();
     accountGuidEntries = new GuidEntry[numAccountGuids];

--- a/src/edu/umass/cs/gnsclient/client/bugreports/SequentialCreateFieldTimeout.java
+++ b/src/edu/umass/cs/gnsclient/client/bugreports/SequentialCreateFieldTimeout.java
@@ -60,14 +60,14 @@ public class SequentialCreateFieldTimeout {
    */
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    client = new GNSClientCommands();
+    client = new GNSClientCommands(new GNSClient());
     // Make all the reads be coordinated
     client.setForceCoordinatedReads(true);
     // arun: connectivity check embedded in GNSClient constructor
-    boolean connected = client instanceof GNSClient;
-    if (connected) {
-      System.out.println("Client created and connected to server.");
-    }
+//    boolean connected = client instanceof GNSClient;
+//    if (connected) {
+//      System.out.println("Client created and connected to server.");
+//    }
     //
     int tries = 5;
     boolean accountCreated = false;

--- a/src/edu/umass/cs/gnsclient/client/bugreports/SomeReadsEncryptionFails.java
+++ b/src/edu/umass/cs/gnsclient/client/bugreports/SomeReadsEncryptionFails.java
@@ -9,7 +9,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Assert;
-import org.json.JSONException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -19,6 +18,7 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig.TC;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSClientConfig;
 import edu.umass.cs.gnsclient.client.testing.GNSTestingConfig.GNSTC;
@@ -92,7 +92,7 @@ public class SomeReadsEncryptionFails extends DefaultTest {
     executor = (ScheduledThreadPoolExecutor) Executors
             .newScheduledThreadPool(numClients);
     for (int i = 0; i < numClients; i++) {
-      clients[i] = new GNSClientCommands();
+      clients[i] = new GNSClientCommands(new GNSClient());
     }
     String gnsInstance = clients[0].getGNSProvider();
     accountGuidEntries = new GuidEntry[numAccountGuids];

--- a/src/edu/umass/cs/gnsclient/client/deprecated/examples/ClientAsynchExample.java
+++ b/src/edu/umass/cs/gnsclient/client/deprecated/examples/ClientAsynchExample.java
@@ -82,7 +82,7 @@ public class ClientAsynchExample {
           InvalidKeyException, SignatureException, Exception {
 
     // Create the client
-    GNSClientCommands client = new GNSClientCommands(null);
+    GNSClientCommands client = new GNSClientCommands(new GNSClient());
     GuidEntry accountGuidEntry = null;
     try {
       // Create a guid (which is also an account guid)
@@ -146,7 +146,7 @@ public class ClientAsynchExample {
   }
 
   // Not saying this is the best way to handle responses, but it works for this example.
-  private static void lookForResponses(GNSClient client, Set<Long> pendingIds) {
+  private static void lookForResponses(GNSClientCommands client, Set<Long> pendingIds) {
     while (true) {
       ThreadUtils.sleep(10);
       // Loop through all the ones we've sent

--- a/src/edu/umass/cs/gnsclient/client/deprecated/examples/ContextAwareGroupGuidExample.java
+++ b/src/edu/umass/cs/gnsclient/client/deprecated/examples/ContextAwareGroupGuidExample.java
@@ -19,23 +19,19 @@
  */
 package edu.umass.cs.gnsclient.client.deprecated.examples;
 
-import edu.umass.cs.gnsclient.client.GNSClientConfig;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
-import edu.umass.cs.gnscommon.utils.ByteUtils;
 import edu.umass.cs.gnsclient.client.util.BasicGuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
 import edu.umass.cs.gnsclient.client.util.KeyPairUtils;
-import edu.umass.cs.gnsclient.client.util.SHA1HashFunction;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
-import edu.umass.cs.utils.Config;
 
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
-import java.util.Arrays;
 
 import org.json.JSONArray;
 
@@ -101,7 +97,7 @@ public class ContextAwareGroupGuidExample {
 
     // BOILER PLATE FOR RUNNING AN EXAMPLE
     // Start the client
-    client = new GNSClientCommands(null);
+    client = new GNSClientCommands(new GNSClient());
     try {
       // Create the account guid using your email address and password = "password"
       masterGuid = lookupOrCreateAccountGuid(client, ACCOUNT_ALIAS, "password");

--- a/src/edu/umass/cs/gnsclient/client/deprecated/examples/GNSQuickStart.java
+++ b/src/edu/umass/cs/gnsclient/client/deprecated/examples/GNSQuickStart.java
@@ -19,6 +19,7 @@
  */
 package edu.umass.cs.gnsclient.client.deprecated.examples;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.KeyPairUtils;
@@ -86,7 +87,7 @@ public class GNSQuickStart {
           InvalidKeyException, SignatureException, Exception {
 
     // Create a new client object
-    GNSClientCommands client = new GNSClientCommands(null);
+    GNSClientCommands client = new GNSClientCommands(new GNSClient());
     System.out.println("Client connected to GNS");
 
     // Retrive the GUID using the account id

--- a/src/edu/umass/cs/gnsclient/client/deprecated/examples/SimpleClientExample.java
+++ b/src/edu/umass/cs/gnsclient/client/deprecated/examples/SimpleClientExample.java
@@ -19,6 +19,7 @@
  */
 package edu.umass.cs.gnsclient.client.deprecated.examples;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -66,7 +67,7 @@ public class SimpleClientExample {
           InvalidKeyException, SignatureException, Exception {
     
     // Create the client. Connects to a default reconfigurator as specified in gigapaxos.properties file.
-    client = new GNSClientCommands();
+    client = new GNSClientCommands(new GNSClient());
     try {
       // Create an account guid if one doesn't already exists.
       // The true makes it verbosely print out what it is doing.

--- a/src/edu/umass/cs/gnsclient/client/testing/BatchCreateTest.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/BatchCreateTest.java
@@ -38,6 +38,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import static edu.umass.cs.gnsclient.client.CommandUtils.*;
+
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnscommon.packets.CommandPacket;
 import edu.umass.cs.gnscommon.utils.RandomString;
@@ -79,7 +81,7 @@ public class BatchCreateTest {
    */
   public BatchCreateTest(String accountGuidAlias, int numberToCreate, int writeTo) {
     try {
-      client = new GNSClientCommands(null);
+      client = new GNSClientCommands(new GNSClient());
     } catch (IOException e) {
       System.out.println("Unable to create client: " + e);
       e.printStackTrace();
@@ -160,7 +162,7 @@ public class BatchCreateTest {
       try {
         command = createCommand(CommandType.LookupRandomGuids,
                 GNSProtocol.GUID.toString(), masterGuid.getGuid(), GNSProtocol.GUIDCNT.toString(), writeTo);
-        result = client.execute(new CommandPacket((long)(Math.random()*Long.MAX_VALUE), command)).getResultString();
+        result = client.getGNSClient().execute(new CommandPacket((long)(Math.random()*Long.MAX_VALUE), command)).getResultString();
         //checkResponse(client.sendCommandAndWait(command));
         if (!result.startsWith(GNSProtocol.BAD_RESPONSE.toString())) {
           randomGuids = new JSONArray(result);

--- a/src/edu/umass/cs/gnsclient/client/testing/CreateGuidTest.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/CreateGuidTest.java
@@ -19,6 +19,7 @@
  */
 package edu.umass.cs.gnsclient.client.testing;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -57,7 +58,7 @@ public class CreateGuidTest {
   public CreateGuidTest(String alias) {
     if (client == null) {
       try {
-        client = new GNSClientCommands(null);
+        client = new GNSClientCommands(new GNSClient());
       } catch (IOException e) {
         System.out.println("Unable to create client: " + e);
         e.printStackTrace();

--- a/src/edu/umass/cs/gnsclient/client/testing/CreateMultiGuidClient.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/CreateMultiGuidClient.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Executors;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.KeyPairUtils;
@@ -49,7 +50,7 @@ public class CreateMultiGuidClient {
 //		String code64 = Base64.encodeToString(code.getBytes("utf-8"), true);
 //		String mal_code = new String(Files.readAllBytes(Paths.get(mal_file)));		
 //		String mal_code64 = Base64.encodeToString(mal_code.getBytes("utf-8"), true);
-    client = new GNSClientCommands();
+    client = new GNSClientCommands(new GNSClient());
     ExecutorService executor = Executors.newFixedThreadPool(numThread);
 
     for (int i = 0; i < NUM_CLIENT; i++) {

--- a/src/edu/umass/cs/gnsclient/client/testing/GNSClientCapacityTest.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/GNSClientCapacityTest.java
@@ -21,7 +21,6 @@ import org.junit.runner.notification.Failure;
 
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig.TC;
 import edu.umass.cs.gnsclient.client.GNSClient;
-import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSClientConfig;
 import edu.umass.cs.gnsclient.client.GNSCommand;
 import edu.umass.cs.gnsclient.client.testing.GNSTestingConfig.GNSTC;
@@ -32,7 +31,6 @@ import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnscommon.GNSProtocol;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
 import edu.umass.cs.gnscommon.exceptions.client.DuplicateNameException;
-import edu.umass.cs.gnscommon.packets.CommandPacket;
 import edu.umass.cs.utils.Config;
 import edu.umass.cs.utils.DefaultTest;
 import edu.umass.cs.utils.DelayProfiler;
@@ -97,7 +95,7 @@ public class GNSClientCapacityTest extends DefaultTest {
 		executor = (ThreadPoolExecutor) Executors
 				.newFixedThreadPool(50*numClients);
 		for (int i = 0; i < numClients; i++)
-			clients[i] = new GNSClientCommands();
+			clients[i] = new GNSClient();
 		@SuppressWarnings("deprecation")
 		String gnsInstance = GNSClient.getGNSProvider();
 		accountGuidEntries = new GuidEntry[numAccountGuids];

--- a/src/edu/umass/cs/gnsclient/client/testing/ReplicaLatencyTest.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/ReplicaLatencyTest.java
@@ -19,6 +19,7 @@
  */
 package edu.umass.cs.gnsclient.client.testing;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -93,7 +94,7 @@ public class ReplicaLatencyTest {
 
     if (client == null) {
       try {
-        client = new GNSClientCommands(null);
+        client = new GNSClientCommands(new GNSClient());
       } catch (IOException e) {
         System.out.println("Unable to create client: " + e);
         e.printStackTrace();

--- a/src/edu/umass/cs/gnsclient/client/testing/ThroughputAsynchMultiClientTest.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/ThroughputAsynchMultiClientTest.java
@@ -199,7 +199,7 @@ public class ThroughputAsynchMultiClientTest {
     chosen = Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
     try {
       for (int i = 0; i < numberOfClients; i++) {
-        clients[i] = new GNSClientCommands(null);
+        clients[i] = new GNSClientCommands(new GNSClient());
       }
     } catch (IOException e) {
       System.out.println("Unable to create client: " + e);
@@ -264,11 +264,11 @@ public class ThroughputAsynchMultiClientTest {
       for (int clientIndex = 0; clientIndex < numberOfClients; clientIndex++) {
         for (int i = 0; i < numberOfGuids; i++) {
           if (doingReads) {
-            commmandPackets[i][clientIndex] = createReadCommandPacket(clients[clientIndex], subGuids[i], updateField, masterGuid);
+            commmandPackets[i][clientIndex] = createReadCommandPacket(clients[clientIndex].getGNSClient(), subGuids[i], updateField, masterGuid);
           } else {
             JSONObject json = new JSONObject();
             json.put(updateField, updateValue);
-            commmandPackets[i][clientIndex] = createUpdateCommandPacket(clients[clientIndex], subGuids[i], json, masterGuid);
+            commmandPackets[i][clientIndex] = createUpdateCommandPacket(clients[clientIndex].getGNSClient(), subGuids[i], json, masterGuid);
           }
         }
       }
@@ -325,7 +325,7 @@ public class ThroughputAsynchMultiClientTest {
         try {
           JSONObject command = createCommand(CommandType.LookupRandomGuids,
                   GNSProtocol.GUID.toString(), masterGuid.getGuid(), GNSProtocol.GUIDCNT.toString(), numberOfGuids);
-					String result = clients[0].execute(
+					String result = clients[0].getGNSClient().execute(
 							new CommandPacket(
 									(long) (Math.random() * Long.MAX_VALUE),
 									command)).getResultString();// checkResponse(clients[0].sendCommandAndWait(command));

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/CapacityTestForLatencyClient.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/CapacityTestForLatencyClient.java
@@ -9,10 +9,10 @@ import java.io.PrintWriter;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import edu.umass.cs.gigapaxos.paxosutil.RateLimiter;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnscommon.exceptions.client.EncryptionException;
@@ -122,7 +122,7 @@ public class CapacityTestForLatencyClient{
 		
 		clients = new GNSClientCommands[numClients];
 		for (int i=0; i<numClients; i++){
-			clients[i] = new GNSClientCommands();
+			clients[i] = new GNSClientCommands(new GNSClient());
 		}
 	}
 	

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/CapacityTestForThruputClient.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/CapacityTestForThruputClient.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig.TC;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSClientConfig.GNSCC;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
@@ -118,7 +119,7 @@ final static Random random = new Random();
 		
 		clients = new GNSClientCommands[numClients];
 		for (int i=0; i<numClients; i++){
-			clients[i] = new GNSClientCommands();
+			clients[i] = new GNSClientCommands(new GNSClient());
 		}
 	}
 	

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/GNSClientCapacityTest.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/GNSClientCapacityTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.json.JSONException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -22,6 +21,7 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig.TC;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSClientConfig;
 import edu.umass.cs.gnsclient.client.GNSClientConfig.GNSCC;
@@ -101,7 +101,7 @@ public class GNSClientCapacityTest extends DefaultTest {
 		executor = (ScheduledThreadPoolExecutor) Executors
 				.newScheduledThreadPool(numClients);
 		for (int i = 0; i < numClients; i++)
-			clients[i] = new GNSClientCommands();
+			clients[i] = new GNSClientCommands(new GNSClient());
 		String gnsInstance = clients[0].getGNSProvider();
 		accountGuidEntries = new GuidEntry[numAccountGuids];
 

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/SetupChainCode.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/SetupChainCode.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -48,7 +49,7 @@ public class SetupChainCode {
 		
 		String code = new String(Files.readAllBytes(Paths.get(codeFile)));
 		
-		client = new GNSClientCommands();	
+		client = new GNSClientCommands(new GNSClient());	
 		
 		for (int j=0; j<numChains; j++){
 			entries = new GuidEntry[depth];

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveACL.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/TestActiveACL.java
@@ -11,6 +11,7 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -45,7 +46,7 @@ public class TestActiveACL extends DefaultTest {
 	 */
 	@BeforeClass
 	public static void setupClientsAndGuids() throws Exception {
-		client = new GNSClientCommands();
+		client = new GNSClientCommands(new GNSClient());
 		entries = new GuidEntry[numGuid];
 		
 		// initialize three GUID

--- a/src/edu/umass/cs/gnsclient/client/testing/activecode/TestUnsignedRead.java
+++ b/src/edu/umass/cs/gnsclient/client/testing/activecode/TestUnsignedRead.java
@@ -1,5 +1,6 @@
 package edu.umass.cs.gnsclient.client.testing.activecode;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -23,7 +24,7 @@ public class TestUnsignedRead {
 	 */
 	public static void main(String[] args) throws Exception{
 		
-		final GNSClientCommands client = new GNSClientCommands();
+		final GNSClientCommands client = new GNSClientCommands(new GNSClient());
 		GuidEntry entry = GuidUtils.lookupOrCreateAccountGuid(
 				client, ACCOUNT_GUID, PASSWORD);
 		

--- a/src/edu/umass/cs/gnsclient/client/util/GuidEntry.java
+++ b/src/edu/umass/cs/gnsclient/client/util/GuidEntry.java
@@ -19,6 +19,7 @@
  */
 package edu.umass.cs.gnsclient.client.util;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 
 import edu.umass.cs.gnscommon.GNSProtocol;
@@ -202,7 +203,7 @@ public static void main(String[] args) throws IOException, Exception {
     String password = "123";
     String file_name = "guid";
 
-    GNSClientCommands client = new GNSClientCommands();
+    GNSClientCommands client = new GNSClientCommands(new GNSClient());
 
     GuidEntry guidEntry = client.accountGuidCreate(name, password);
 

--- a/src/edu/umass/cs/gnsclient/console/commands/Connect.java
+++ b/src/edu/umass/cs/gnsclient/console/commands/Connect.java
@@ -20,6 +20,8 @@
 package edu.umass.cs.gnsclient.console.commands;
 
 import java.util.StringTokenizer;
+
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.console.ConsoleModule;
 
@@ -75,7 +77,7 @@ public class Connect extends ConsoleCommand {
       }
 
       GNSClientCommands gnsClient;
-      gnsClient = new GNSClientCommands();
+      gnsClient = new GNSClientCommands(new GNSClient());
       if (!module.isSilent()) {
         console.printString("Connected to GNS.\n");
       }

--- a/src/edu/umass/cs/gnsclient/examples/ClientACLExample.java
+++ b/src/edu/umass/cs/gnsclient/examples/ClientACLExample.java
@@ -17,7 +17,6 @@ package edu.umass.cs.gnsclient.examples;
 
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.GNSClient;
-import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSCommand;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
 import edu.umass.cs.gnscommon.AclAccessType;
@@ -66,7 +65,7 @@ public class ClientACLExample {
 			InvalidKeySpecException, NoSuchAlgorithmException, ClientException,
 			InvalidKeyException, SignatureException, Exception {
 
-		client = new GNSClientCommands();
+		client = new GNSClient();
 		System.out.println("[Client connected to GNS]\n");
 
 		try {

--- a/src/edu/umass/cs/gnsclient/examples/ClientWebACLExample.java
+++ b/src/edu/umass/cs/gnsclient/examples/ClientWebACLExample.java
@@ -1,13 +1,11 @@
 package edu.umass.cs.gnsclient.examples;
 
 import edu.umass.cs.gnsclient.client.GNSClient;
-import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSCommand;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
 import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
-import edu.umass.cs.gnscommon.exceptions.client.InvalidGuidException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -44,7 +42,7 @@ public class ClientWebACLExample {
             InvalidKeySpecException, NoSuchAlgorithmException, ClientException,
             InvalidKeyException, SignatureException, JSONException {
 
-        client = new GNSClientCommands();
+        client = new GNSClient();
         System.out.println("[Client connected to GNS]\n");
 
         try {

--- a/src/edu/umass/cs/gnsclient/examples/CreateDnsRecord.java
+++ b/src/edu/umass/cs/gnsclient/examples/CreateDnsRecord.java
@@ -19,6 +19,7 @@
  */
 package edu.umass.cs.gnsclient.examples;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -59,7 +60,7 @@ public class CreateDnsRecord {
       System.out.println("Usage: edu.umass.cs.gnsclient.examples.CreateDnsRecord <host> <address>");
       System.exit(0);
     }
-    client = new GNSClientCommands();
+    client = new GNSClientCommands(new GNSClient());
     try {
       accountGuid = GuidUtils.lookupOrCreateAccountGuid(client, ACCOUNT_ALIAS, "password", true);
     } catch (Exception e) {

--- a/src/edu/umass/cs/gnsclient/examples/CreateSomeRecordsForDns.java
+++ b/src/edu/umass/cs/gnsclient/examples/CreateSomeRecordsForDns.java
@@ -19,6 +19,7 @@
  */
 package edu.umass.cs.gnsclient.examples;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -55,7 +56,7 @@ public class CreateSomeRecordsForDns {
           InvalidKeySpecException, NoSuchAlgorithmException, ClientException,
           InvalidKeyException, SignatureException, Exception {
 
-    client = new GNSClientCommands();
+    client = new GNSClientCommands(new GNSClient());
     try {
       accountGuid = GuidUtils.lookupOrCreateAccountGuid(client, ACCOUNT_ALIAS, "password", true);
     } catch (Exception e) {

--- a/src/edu/umass/cs/gnsclient/examples/GNSClientCommandsExample.java
+++ b/src/edu/umass/cs/gnsclient/examples/GNSClientCommandsExample.java
@@ -15,6 +15,7 @@
  * Initial developer(s): Westy */
 package edu.umass.cs.gnsclient.examples;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -64,7 +65,7 @@ public class GNSClientCommandsExample {
 
     /* Create the client that connects to a default reconfigurator as
 		 * specified in gigapaxos properties file. */
-    client = new GNSClientCommands();
+    client = new GNSClientCommands(new GNSClient() );
     System.out.println("[Client connected to GNS]\n");
 
     try {

--- a/src/edu/umass/cs/gnsserver/gnamed/CreateDNSRecordExample.java
+++ b/src/edu/umass/cs/gnsserver/gnamed/CreateDNSRecordExample.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import org.json.JSONObject;
 
-import edu.umass.cs.gnsclient.client.GNSClientCommands;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSCommand;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -22,7 +22,7 @@ import edu.umass.cs.gnsclient.client.util.GuidUtils;
  */
 public class CreateDNSRecordExample {
 	
-	private static GNSClientCommands client;
+	private static GNSClient client;
 	
 	// The last dot is very important, it tells the DNS to search from the root
 	private static String DOMAIN;
@@ -74,7 +74,7 @@ public class CreateDNSRecordExample {
 		
 		// initialize client and create record for the domain
 		try {
-			client = new GNSClientCommands();
+			client = new GNSClient();
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/edu/umass/cs/gnsserver/gnamed/ManagedDNSServiceProxy.java
+++ b/src/edu/umass/cs/gnsserver/gnamed/ManagedDNSServiceProxy.java
@@ -24,6 +24,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSCommand;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
@@ -127,7 +128,7 @@ public class ManagedDNSServiceProxy implements Runnable {
 	private ManagedDNSServiceProxy(){
 		
 		try {
-			client = new GNSClientCommands();
+			client = new GNSClientCommands(new GNSClient());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -253,7 +254,7 @@ public class ManagedDNSServiceProxy implements Runnable {
 		System.out.println("Ready to update record for "+entry+" field:"+fieldToUpdate);
 		JSONObject recordObj = recordToCreate(ips, ttl);
 		try {
-			client.execute(GNSCommand.fieldUpdate(entry, fieldToUpdate, recordObj));
+			client.getGNSClient().execute(GNSCommand.fieldUpdate(entry, fieldToUpdate, recordObj));
 		} catch (ClientException | IOException e) {
 			// The update failed	
 			e.printStackTrace();					
@@ -266,7 +267,7 @@ public class ManagedDNSServiceProxy implements Runnable {
 	
 	private static void deleteField(GuidEntry entry, String fieldToDelete){
 		try {
-			client.execute(GNSCommand.fieldRemove(entry, fieldToDelete));
+			client.getGNSClient().execute(GNSCommand.fieldRemove(entry, fieldToDelete));
 		} catch (ClientException | IOException e) {
 			// the delete operation failed
 			e.printStackTrace();
@@ -275,7 +276,7 @@ public class ManagedDNSServiceProxy implements Runnable {
 	
 	private static void updateField(GuidEntry entry, String fieldToUpdate, Object obj){		
 		try {		
-			client.execute(GNSCommand.fieldUpdate(entry, fieldToUpdate, obj));
+			client.getGNSClient().execute(GNSCommand.fieldUpdate(entry, fieldToUpdate, obj));
 		} catch (ClientException | IOException e) {
 			e.printStackTrace();
 		}
@@ -292,7 +293,7 @@ public class ManagedDNSServiceProxy implements Runnable {
 	private static void updateSpecialField(GuidEntry entry, String fieldToUpdate, List<JSONArray> records, int ttl){
 		JSONObject recordObj = generateRecordWithListOfJSONArray(records, ttl);
 		try {
-			client.execute(GNSCommand.fieldUpdate(entry, fieldToUpdate, recordObj));
+			client.getGNSClient().execute(GNSCommand.fieldUpdate(entry, fieldToUpdate, recordObj));
 		} catch (ClientException | IOException e) {
 			// The update failed	
 			e.printStackTrace();					

--- a/test/edu/umass/cs/gnsclient/client/integrationtests/ServerConnectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/integrationtests/ServerConnectTest.java
@@ -232,14 +232,11 @@ public class ServerConnectTest extends DefaultTest {
 	}
     System.out.println("Starting client");
 
-    client = new GNSClientCommands();
+    client = new GNSClientCommands(new GNSClient());
     // Make all the reads be coordinated
     client.setForceCoordinatedReads(true);
     // arun: connectivity check embedded in GNSClient constructor
-    boolean connected = client instanceof GNSClient;
-    if (connected) {
       System.out.println("Client created and connected to server.");
-    }
     //
     int tries = 5;
     boolean accountCreated = false;

--- a/test/edu/umass/cs/gnsclient/client/integrationtests/ServerFailureTests.java
+++ b/test/edu/umass/cs/gnsclient/client/integrationtests/ServerFailureTests.java
@@ -34,12 +34,6 @@ import edu.umass.cs.gnscommon.utils.ThreadUtils;
 import edu.umass.cs.nio.JSONDelayEmulator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * @author Brendan
@@ -226,14 +220,11 @@ public class ServerFailureTests {
     Thread.sleep(5000);
     System.out.println("Starting client");
 
-    client = new GNSClientCommands();
+    client = new GNSClientCommands(new GNSClient());
     // Make all the reads be coordinated
     client.setForceCoordinatedReads(true);
     // arun: connectivity check embedded in GNSClient constructor
-    boolean connected = client instanceof GNSClient;
-    if (connected) {
       System.out.println("Client created and connected to server.");
-    }
     //
     int tries = 5;
     boolean accountCreated = false;

--- a/test/edu/umass/cs/gnsclient/client/integrationtests/ServerIntegrationTest.java
+++ b/test/edu/umass/cs/gnsclient/client/integrationtests/ServerIntegrationTest.java
@@ -222,12 +222,12 @@ public class ServerIntegrationTest extends DefaultGNSTest {
 			IOException, InterruptedException {
 		DefaultGNSTest.setUpBeforeClass();
 		masterGuid = GuidUtils.getGUIDKeys(accountAlias = globalAccountName);
-		clientCommands = (GNSClientCommands) new GNSClientCommands()
-				.setNumRetriesUponTimeout(2).setForceCoordinatedReads(true);
                 client = new GNSClient()
                              .setNumRetriesUponTimeout(2)
                              .setForceCoordinatedReads(true)
                              .setForcedTimeout(8000);
+                
+        clientCommands = new GNSClientCommands(client);
     
 	}
   
@@ -339,14 +339,12 @@ public class ServerIntegrationTest extends DefaultGNSTest {
     int numRetries = 2;
     boolean forceCoordinated = true;
 
-    clientCommands = (GNSClientCommands) new GNSClientCommands()
-            .setNumRetriesUponTimeout(numRetries)
-            .setForceCoordinatedReads(forceCoordinated);
-
     client = new GNSClient()
             .setNumRetriesUponTimeout(numRetries)
             .setForceCoordinatedReads(forceCoordinated)
             .setForcedTimeout(8000);
+    
+    clientCommands =  new GNSClientCommands(client);
 
     System.out.println("Client created and connected to server.");
     //
@@ -3348,12 +3346,12 @@ public class ServerIntegrationTest extends DefaultGNSTest {
     }
     // the HRN is a hash of the query
     String groupOneGuidName = Base64.encodeToString(SHA1HashFunction.getInstance().hash(queryOne), false);
-    GuidEntry groupOneGuid = GuidUtils.lookupOrCreateGuidEntry(groupOneGuidName, GNSClientCommands.getGNSProvider());
+    GuidEntry groupOneGuid = GuidUtils.lookupOrCreateGuidEntry(groupOneGuidName, clientCommands.getGNSProvider());
     //groupGuid = client.guidCreate(masterGuid, groupGuidName + RandomString.randomString(6));
 
     // the HRN is a hash of the query
     String groupTwoGuidName = Base64.encodeToString(SHA1HashFunction.getInstance().hash(queryTwo), false);
-    GuidEntry groupTwoGuid = GuidUtils.lookupOrCreateGuidEntry(groupTwoGuidName, GNSClientCommands.getGNSProvider());
+    GuidEntry groupTwoGuid = GuidUtils.lookupOrCreateGuidEntry(groupTwoGuidName, clientCommands.getGNSProvider());
     //groupTwoGuid = client.guidCreate(masterGuid, groupTwoGuidName + RandomString.randomString(6));
 
     List<GuidEntry> list = new ArrayList<>(2);

--- a/test/edu/umass/cs/gnsclient/client/singletests/AclAllFieldsSuperuser.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/AclAllFieldsSuperuser.java
@@ -50,12 +50,7 @@ public class AclAllFieldsSuperuser extends DefaultGNSTest {
    */
   public AclAllFieldsSuperuser() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: ", e);
-      }
+    	clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/AclDefaultsTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/AclDefaultsTest.java
@@ -65,12 +65,7 @@ public class AclDefaultsTest extends DefaultGNSTest {
    */
   public AclDefaultsTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: ", e);
-      }
+    	clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/AclTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/AclTest.java
@@ -19,11 +19,13 @@
  */
 package edu.umass.cs.gnsclient.client.singletests;
 
-import edu.umass.cs.gnsclient.client.GNSClientCommands;
+
 import edu.umass.cs.gnscommon.AclAccessType;
+
+import edu.umass.cs.gnscommon.utils.RandomString;
+import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
-import edu.umass.cs.gnscommon.utils.RandomString;
 import edu.umass.cs.gnsclient.jsonassert.JSONAssert;
 import edu.umass.cs.gnscommon.GNSProtocol;
 import edu.umass.cs.gnscommon.ResponseCode;
@@ -52,7 +54,7 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AclTest extends DefaultGNSTest {
 
-  private static GNSClientCommands client = null;
+  private static GNSClientCommands clientCommands = null;
   private static GuidEntry masterGuid;
   private static GuidEntry westyEntry;
   private static GuidEntry samEntry;
@@ -63,13 +65,8 @@ public class AclTest extends DefaultGNSTest {
    * This test tests all manner of ACL uses.
    */
   public AclTest() {
-    if (client == null) {
-      try {
-        client = new GNSClientCommands();
-        client.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+    if (clientCommands == null) {
+    	  clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {
@@ -84,8 +81,8 @@ public class AclTest extends DefaultGNSTest {
   @Test
   public void test_100_ACLCreateGuids() {
     try {
-      westyEntry = client.guidCreate(masterGuid, "westy" + RandomString.randomString(12));
-      samEntry = client.guidCreate(masterGuid, "sam" + RandomString.randomString(12));
+      westyEntry = clientCommands.guidCreate(masterGuid, "westy" + RandomString.randomString(12));
+      samEntry = clientCommands.guidCreate(masterGuid, "sam" + RandomString.randomString(12));
       System.out.println("Created: " + westyEntry);
       System.out.println("Created: " + samEntry);
     } catch (ClientException | IOException e) {
@@ -94,14 +91,14 @@ public class AclTest extends DefaultGNSTest {
     }
     try {
       // remove default read access for this test
-      client.aclRemove(AclAccessType.READ_WHITELIST, westyEntry, GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
+      clientCommands.aclRemove(AclAccessType.READ_WHITELIST, westyEntry, GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception while removing ACL in ACLCreateGuids: " + e);
 
     }
     try {
       JSONArray expected = new JSONArray(new ArrayList<>(Arrays.asList(masterGuid.getGuid())));
-      JSONArray actual = client.aclGet(AclAccessType.READ_WHITELIST, westyEntry,
+      JSONArray actual = clientCommands.aclGet(AclAccessType.READ_WHITELIST, westyEntry,
               GNSProtocol.ENTIRE_RECORD.toString(), westyEntry.getGuid());
       JSONAssert.assertEquals(expected, actual, true);
     } catch (ClientException | IOException | JSONException e) {
@@ -116,10 +113,10 @@ public class AclTest extends DefaultGNSTest {
   @Test
   public void test_101_ACLCreateFields() {
     try {
-      client.fieldCreateOneElementList(westyEntry.getGuid(), "environment", "work", westyEntry);
-      client.fieldCreateOneElementList(westyEntry.getGuid(), "ssn", "000-00-0000", westyEntry);
-      client.fieldCreateOneElementList(westyEntry.getGuid(), "password", "666flapJack", westyEntry);
-      client.fieldCreateOneElementList(westyEntry.getGuid(), "address", "100 Hinkledinkle Drive", westyEntry);
+      clientCommands.fieldCreateOneElementList(westyEntry.getGuid(), "environment", "work", westyEntry);
+      clientCommands.fieldCreateOneElementList(westyEntry.getGuid(), "ssn", "000-00-0000", westyEntry);
+      clientCommands.fieldCreateOneElementList(westyEntry.getGuid(), "password", "666flapJack", westyEntry);
+      clientCommands.fieldCreateOneElementList(westyEntry.getGuid(), "address", "100 Hinkledinkle Drive", westyEntry);
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception while creating fields in ACLCreateFields: " + e);
 
@@ -137,7 +134,7 @@ public class AclTest extends DefaultGNSTest {
       expected.put("password", new JSONArray(new ArrayList<>(Arrays.asList("666flapJack"))));
       expected.put("ssn", new JSONArray(new ArrayList<>(Arrays.asList("000-00-0000"))));
       expected.put("address", new JSONArray(new ArrayList<>(Arrays.asList("100 Hinkledinkle Drive"))));
-      JSONObject actual = new JSONObject(client.fieldRead(westyEntry.getGuid(), GNSProtocol.ENTIRE_RECORD.toString(), masterGuid));
+      JSONObject actual = new JSONObject(clientCommands.fieldRead(westyEntry.getGuid(), GNSProtocol.ENTIRE_RECORD.toString(), masterGuid));
       JSONAssert.assertEquals(expected, actual, true);
     } catch (ClientException | IOException | JSONException e) {
       Utils.failWithStackTrace("Exception while reading all fields in ACLReadAllFields: " + e);
@@ -153,10 +150,10 @@ public class AclTest extends DefaultGNSTest {
     try {
       // read my own field
       Assert.assertEquals("work",
-              client.fieldReadArrayFirstElement(westyEntry.getGuid(), "environment", westyEntry));
+              clientCommands.fieldReadArrayFirstElement(westyEntry.getGuid(), "environment", westyEntry));
       // read another one of my fields field
       Assert.assertEquals("000-00-0000",
-              client.fieldReadArrayFirstElement(westyEntry.getGuid(), "ssn", westyEntry));
+              clientCommands.fieldReadArrayFirstElement(westyEntry.getGuid(), "ssn", westyEntry));
 
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception while reading fields in ACLReadMyFields: " + e);
@@ -171,7 +168,7 @@ public class AclTest extends DefaultGNSTest {
   public void test_105_ACLNotReadOtherGuidAllFieldsTest() {
     try {
       try {
-        String result = client.fieldRead(westyEntry.getGuid(), GNSProtocol.ENTIRE_RECORD.toString(), samEntry);
+        String result = clientCommands.fieldRead(westyEntry.getGuid(), GNSProtocol.ENTIRE_RECORD.toString(), samEntry);
         Utils.failWithStackTrace("Result of read of all of westy's fields by sam is " + result
                 + " which is wrong because it should have been rejected.");
       } catch (ClientException e) {
@@ -190,7 +187,7 @@ public class AclTest extends DefaultGNSTest {
   public void test_106_ACLNotReadOtherGuidFieldTest() {
     try {
       try {
-        String result = client.fieldReadArrayFirstElement(westyEntry.getGuid(), "environment",
+        String result = clientCommands.fieldReadArrayFirstElement(westyEntry.getGuid(), "environment",
                 samEntry);
         Utils.failWithStackTrace("Result of read of westy's environment by sam is " + result
                 + " which is wrong because it should have been rejected.");
@@ -209,14 +206,14 @@ public class AclTest extends DefaultGNSTest {
   public void test_110_ACLPartOne() {
     try {
       try {
-        client.aclAdd(AclAccessType.READ_WHITELIST, westyEntry, "environment", samEntry.getGuid());
+        clientCommands.aclAdd(AclAccessType.READ_WHITELIST, westyEntry, "environment", samEntry.getGuid());
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Exception adding Sam to Westy's readlist: " + e);
 
       }
       try {
         Assert.assertEquals("work",
-                client.fieldReadArrayFirstElement(westyEntry.getGuid(), "environment", samEntry));
+                clientCommands.fieldReadArrayFirstElement(westyEntry.getGuid(), "environment", samEntry));
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Exception while Sam reading Westy's field: " + e);
 
@@ -235,7 +232,7 @@ public class AclTest extends DefaultGNSTest {
     try {
       String barneyName = "barney" + RandomString.randomString(12);
       try {
-        client.lookupGuid(barneyName);
+        clientCommands.lookupGuid(barneyName);
         Utils.failWithStackTrace(barneyName + " entity should not exist");
       } catch (ClientException e) {
         // Normal result
@@ -243,16 +240,16 @@ public class AclTest extends DefaultGNSTest {
         Utils.failWithStackTrace("Exception looking up Barney: " + e);
 
       }
-      barneyEntry = client.guidCreate(masterGuid, barneyName);
+      barneyEntry = clientCommands.guidCreate(masterGuid, barneyName);
       // remove default read access for this test
-      client.aclRemove(AclAccessType.READ_WHITELIST, barneyEntry,
+      clientCommands.aclRemove(AclAccessType.READ_WHITELIST, barneyEntry,
               GNSProtocol.ENTIRE_RECORD.toString(), GNSProtocol.ALL_GUIDS.toString());
-      client.fieldCreateOneElementList(barneyEntry.getGuid(), "cell", "413-555-1234", barneyEntry);
-      client.fieldCreateOneElementList(barneyEntry.getGuid(), "address", "100 Main Street", barneyEntry);
+      clientCommands.fieldCreateOneElementList(barneyEntry.getGuid(), "cell", "413-555-1234", barneyEntry);
+      clientCommands.fieldCreateOneElementList(barneyEntry.getGuid(), "address", "100 Main Street", barneyEntry);
 
       try {
         // let anybody read barney's cell field
-        client.aclAdd(AclAccessType.READ_WHITELIST, barneyEntry, "cell",
+        clientCommands.aclAdd(AclAccessType.READ_WHITELIST, barneyEntry, "cell",
                 GNSProtocol.ALL_GUIDS.toString());
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Exception creating ALLUSERS access for Barney's cell: " + e);
@@ -261,7 +258,7 @@ public class AclTest extends DefaultGNSTest {
 
       try {
         Assert.assertEquals("413-555-1234",
-                client.fieldReadArrayFirstElement(barneyEntry.getGuid(), "cell", samEntry));
+                clientCommands.fieldReadArrayFirstElement(barneyEntry.getGuid(), "cell", samEntry));
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Exception while Sam reading Barney' cell: " + e);
 
@@ -269,14 +266,14 @@ public class AclTest extends DefaultGNSTest {
 
       try {
         Assert.assertEquals("413-555-1234",
-                client.fieldReadArrayFirstElement(barneyEntry.getGuid(), "cell", westyEntry));
+                clientCommands.fieldReadArrayFirstElement(barneyEntry.getGuid(), "cell", westyEntry));
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Exception while Westy reading Barney' cell: " + e);
 
       }
 
       try {
-        String result = client.fieldReadArrayFirstElement(barneyEntry.getGuid(), "address",
+        String result = clientCommands.fieldReadArrayFirstElement(barneyEntry.getGuid(), "address",
                 samEntry);
         Utils.failWithStackTrace("Result of read of barney's address by sam is " + result
                 + " which is wrong because it should have been rejected.");
@@ -308,22 +305,22 @@ public class AclTest extends DefaultGNSTest {
     String superUserName = "superuser" + RandomString.randomString(12);
     try {
       try {
-        client.lookupGuid(superUserName);
+        clientCommands.lookupGuid(superUserName);
         Utils.failWithStackTrace(superUserName + " entity should not exist");
       } catch (ClientException e) {
       }
 
-      GuidEntry superuserEntry = client.guidCreate(masterGuid, superUserName);
+      GuidEntry superuserEntry = clientCommands.guidCreate(masterGuid, superUserName);
 
       // let superuser read any of barney's fields
-      client.aclAdd(AclAccessType.READ_WHITELIST, barneyEntry, GNSProtocol.ENTIRE_RECORD.toString(), superuserEntry.getGuid());
+      clientCommands.aclAdd(AclAccessType.READ_WHITELIST, barneyEntry, GNSProtocol.ENTIRE_RECORD.toString(), superuserEntry.getGuid());
 
       Assert.assertEquals("413-555-1234",
-              client.fieldReadArrayFirstElement(barneyEntry.getGuid(), "cell", superuserEntry));
+              clientCommands.fieldReadArrayFirstElement(barneyEntry.getGuid(), "cell", superuserEntry));
       Assert.assertEquals("100 Main Street",
-              client.fieldReadArrayFirstElement(barneyEntry.getGuid(), "address", superuserEntry));
+              clientCommands.fieldReadArrayFirstElement(barneyEntry.getGuid(), "address", superuserEntry));
       try {
-        client.guidRemove(masterGuid, superuserEntry.getGuid());
+        clientCommands.guidRemove(masterGuid, superuserEntry.getGuid());
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Exception while removing superuserEntry in  ACLALLFields: " + e);
       }
@@ -339,19 +336,19 @@ public class AclTest extends DefaultGNSTest {
   public void test_140_ACLCreateDeeperField() {
     try {
       try {
-        client.fieldUpdate(westyEntry.getGuid(), "test.deeper.field", "fieldValue", westyEntry);
+        clientCommands.fieldUpdate(westyEntry.getGuid(), "test.deeper.field", "fieldValue", westyEntry);
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Problem updating field: " + e);
 
       }
       try {
-        client.aclAdd(AclAccessType.READ_WHITELIST, westyEntry, "test.deeper.field", GNSProtocol.ALL_GUIDS.toString());
+        clientCommands.aclAdd(AclAccessType.READ_WHITELIST, westyEntry, "test.deeper.field", GNSProtocol.ALL_GUIDS.toString());
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Problem adding acl: " + e);
 
       }
       try {
-        JSONArray actual = client.aclGet(AclAccessType.READ_WHITELIST, westyEntry,
+        JSONArray actual = clientCommands.aclGet(AclAccessType.READ_WHITELIST, westyEntry,
                 "test.deeper.field", westyEntry.getGuid());
         JSONArray expected = new JSONArray(new ArrayList<>(Arrays.asList(GNSProtocol.ALL_GUIDS.toString())));
         JSONAssert.assertEquals(expected, actual, true);
@@ -371,7 +368,7 @@ public class AclTest extends DefaultGNSTest {
   @Test
   public void test_142_ACLRemoveDeeperFieldACL() {
     try {
-      client.aclRemove(AclAccessType.READ_WHITELIST, westyEntry,
+      clientCommands.aclRemove(AclAccessType.READ_WHITELIST, westyEntry,
               "test.deeper.field", GNSProtocol.ALL_GUIDS.toString());
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception when we were not expecting it ACLRemoveDeeperFieldACL: " + e);
@@ -387,7 +384,7 @@ public class AclTest extends DefaultGNSTest {
     try {
       JSONArray expected = new JSONArray();
       JSONAssert.assertEquals(expected,
-              client.aclGet(AclAccessType.READ_WHITELIST, westyEntry,
+              clientCommands.aclGet(AclAccessType.READ_WHITELIST, westyEntry,
                       "test.deeper.field", masterGuid.getGuid()), true);
     } catch (ClientException | IOException | JSONException e) {
       Utils.failWithStackTrace("Exception when we were not expecting it ACLCheckDeeperFieldEmpty: " + e);
@@ -401,7 +398,7 @@ public class AclTest extends DefaultGNSTest {
   @Test
   public void test_145_ACLRemoveDeeperFieldACLAgain() {
     try {
-      client.aclRemove(AclAccessType.READ_WHITELIST, westyEntry,
+      clientCommands.aclRemove(AclAccessType.READ_WHITELIST, westyEntry,
               "test.deeper.field", GNSProtocol.ALL_GUIDS.toString());
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception when we were not expecting it ACLRemoveDeeperFieldACL: " + e);
@@ -415,7 +412,7 @@ public class AclTest extends DefaultGNSTest {
   @Test
   public void test_146_ACLCheckDeeperFieldACLExists() {
     try {
-      Assert.assertTrue(client.fieldAclExists(AclAccessType.READ_WHITELIST, westyEntry,
+      Assert.assertTrue(clientCommands.fieldAclExists(AclAccessType.READ_WHITELIST, westyEntry,
               "test.deeper.field"));
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception when we were not expecting it ACLCheckDeeperFieldACLExists: " + e);
@@ -430,7 +427,7 @@ public class AclTest extends DefaultGNSTest {
   public void test_148_ACLDeleteDeeperFieldACL() {
     try {
       try {
-        client.fieldDeleteAcl(AclAccessType.READ_WHITELIST, westyEntry, "test.deeper.field");
+        clientCommands.fieldDeleteAcl(AclAccessType.READ_WHITELIST, westyEntry, "test.deeper.field");
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Problem deleting acl: " + e);
 
@@ -448,7 +445,7 @@ public class AclTest extends DefaultGNSTest {
   public void test_150_CheckDeeperFieldACLExists() {
     try {
       try {
-        Assert.assertFalse(client.fieldAclExists(AclAccessType.READ_WHITELIST, westyEntry, "test.deeper.field"));
+        Assert.assertFalse(clientCommands.fieldAclExists(AclAccessType.READ_WHITELIST, westyEntry, "test.deeper.field"));
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Problem checking acl exists: " + e);
 
@@ -466,7 +463,7 @@ public class AclTest extends DefaultGNSTest {
   public void test_152_ACLDeleteDeeperFieldACLAgain() {
     try {
       try {
-        client.fieldDeleteAcl(AclAccessType.READ_WHITELIST, westyEntry, "test.deeper.field");
+        clientCommands.fieldDeleteAcl(AclAccessType.READ_WHITELIST, westyEntry, "test.deeper.field");
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Problem deleting acl: " + e);
 
@@ -484,7 +481,7 @@ public class AclTest extends DefaultGNSTest {
   public void test_154_ACLRemoveFromNonexistantField() {
     try {
       try {
-        client.aclRemove(AclAccessType.READ_WHITELIST, westyEntry, "NonexistantField", 
+        clientCommands.aclRemove(AclAccessType.READ_WHITELIST, westyEntry, "NonexistantField", 
                 GNSProtocol.ALL_GUIDS.toString());
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Problem removing acl: " + e);
@@ -504,7 +501,7 @@ public class AclTest extends DefaultGNSTest {
   public void test_156_ACLDeleteNonexistantField() {
     try {
       try {
-        client.fieldDeleteAcl(AclAccessType.READ_WHITELIST, westyEntry, "NonexistantField");
+        clientCommands.fieldDeleteAcl(AclAccessType.READ_WHITELIST, westyEntry, "NonexistantField");
       } catch (ClientException | IOException e) {
         Utils.failWithStackTrace("Problem deleting acl: " + e);
 
@@ -521,9 +518,9 @@ public class AclTest extends DefaultGNSTest {
   @Test
   public void test_999_ACLTestCleanup() {
     try {
-      client.guidRemove(masterGuid, barneyEntry.getGuid());
-      client.guidRemove(masterGuid, westyEntry.getGuid());
-      client.guidRemove(masterGuid, samEntry.getGuid());
+      clientCommands.guidRemove(masterGuid, barneyEntry.getGuid());
+      clientCommands.guidRemove(masterGuid, westyEntry.getGuid());
+      clientCommands.guidRemove(masterGuid, samEntry.getGuid());
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception during cleanup: " + e);
     }

--- a/test/edu/umass/cs/gnsclient/client/singletests/ActiveCodeTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/ActiveCodeTest.java
@@ -38,12 +38,7 @@ public class ActiveCodeTest extends DefaultGNSTest {
    */
   public ActiveCodeTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/AdminTestSuite.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/AdminTestSuite.java
@@ -18,7 +18,6 @@
  */
 package edu.umass.cs.gnsclient.client.singletests;
 
-import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -53,14 +52,10 @@ public class AdminTestSuite extends DefaultGNSTest {
   public static void setupBeforeClass() throws IOException {
     System.out.println("Starting client");
 
-    clientCommands = new GNSClientCommands();
-    // Make all the reads be coordinated
-    clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-    // arun: connectivity check embedded in GNSClient constructor
-    boolean connected = clientCommands instanceof GNSClient;
-    if (connected) {
-      System.out.println("Client created and connected to server.");
-    }
+    clientCommands = new GNSClientCommands(client);
+    
+    System.out.println("Client created and connected to server.");
+    
     //
     int tries = 5;
     boolean accountCreated = false;

--- a/test/edu/umass/cs/gnsclient/client/singletests/AliasTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/AliasTest.java
@@ -55,11 +55,7 @@ public class AliasTest extends DefaultGNSTest {
    */
   public AliasTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = (GNSClientCommands)new GNSClientCommands().setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+    	clientCommands = (GNSClientCommands)new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/BatchCreateTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/BatchCreateTest.java
@@ -56,12 +56,7 @@ public class BatchCreateTest extends DefaultGNSTest {
    */
   public BatchCreateTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/ClientLNSTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/ClientLNSTest.java
@@ -46,15 +46,10 @@ public class ClientLNSTest extends DefaultGNSTest {
    */
   public ClientLNSTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+    	clientCommands = new GNSClientCommands(client);
         //PaxosConfig.getActives() works here because the server and client use the same properties file.
         InetAddress lnsAddress = PaxosConfig.getActives().values().iterator().next().getAddress();
         clientCommands.setGNSProxy(new InetSocketAddress(lnsAddress, 24598));
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/ClientLNSTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/ClientLNSTest.java
@@ -71,6 +71,8 @@ public class ClientLNSTest extends DefaultGNSTest {
         Utils.failWithStackTrace("Exception while looking up account record: " + e);
       }
     }
+    // Setting proxy to null, so that LNS is not used in later tests.
+    clientCommands.setGNSProxy(null);
   }
 
 }

--- a/test/edu/umass/cs/gnsclient/client/singletests/ContextServiceTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/ContextServiceTest.java
@@ -25,15 +25,11 @@ import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
 
-import edu.umass.cs.gnscommon.GNSProtocol;
-import edu.umass.cs.gnscommon.exceptions.client.ClientException;
-import edu.umass.cs.gnscommon.utils.RandomString;
 import edu.umass.cs.gnsserver.main.GNSConfig;
 import edu.umass.cs.gnsserver.utils.DefaultGNSTest;
 import edu.umass.cs.utils.Config;
 import edu.umass.cs.utils.Repeat;
 import edu.umass.cs.utils.Utils;
-import java.io.IOException;
 
 import org.hamcrest.Matchers;
 import org.json.JSONArray;
@@ -62,12 +58,7 @@ public class ContextServiceTest extends DefaultGNSTest {
    */
   public ContextServiceTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
     }
     try {
       masterGuid = GuidUtils.getGUIDKeys(globalAccountName);

--- a/test/edu/umass/cs/gnsclient/client/singletests/CreateGuidBatchTestWithPublicKeys.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/CreateGuidBatchTestWithPublicKeys.java
@@ -55,12 +55,7 @@ public class CreateGuidBatchTestWithPublicKeys extends DefaultGNSTest {
   public CreateGuidBatchTestWithPublicKeys() {
 
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+    	clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/CreateGuidTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/CreateGuidTest.java
@@ -51,12 +51,7 @@ public class CreateGuidTest extends DefaultGNSTest {
   public CreateGuidTest() {
 
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/CreateIndexTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/CreateIndexTest.java
@@ -61,12 +61,7 @@ public class CreateIndexTest extends DefaultGNSTest {
    */
   public CreateIndexTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/CreateUpdateRemoveRepeatTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/CreateUpdateRemoveRepeatTest.java
@@ -27,7 +27,6 @@ import edu.umass.cs.gnscommon.utils.RandomString;
 import edu.umass.cs.gnsserver.utils.DefaultGNSTest;
 import edu.umass.cs.utils.Repeat;
 import edu.umass.cs.utils.Utils;
-import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;
@@ -51,12 +50,7 @@ public class CreateUpdateRemoveRepeatTest extends DefaultGNSTest {
    */
   public CreateUpdateRemoveRepeatTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
     }
     try {
       masterGuid = GuidUtils.getGUIDKeys(globalAccountName);

--- a/test/edu/umass/cs/gnsclient/client/singletests/DatabaseTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/DatabaseTest.java
@@ -67,12 +67,7 @@ public class DatabaseTest extends DefaultGNSTest {
    */
   public DatabaseTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/DottedReadTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/DottedReadTest.java
@@ -56,12 +56,7 @@ public class DottedReadTest extends DefaultGNSTest {
    */
   public DottedReadTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/FieldExistsTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/FieldExistsTest.java
@@ -52,12 +52,7 @@ public class FieldExistsTest extends DefaultGNSTest {
    */
   public FieldExistsTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/GroupAddTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/GroupAddTest.java
@@ -63,12 +63,7 @@ public class GroupAddTest extends DefaultGNSTest {
    */
   public GroupAddTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: ", e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/GroupAndAclTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/GroupAndAclTest.java
@@ -76,12 +76,7 @@ public class GroupAndAclTest extends DefaultGNSTest {
    */
   public GroupAndAclTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception while creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/GroupSingleAddTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/GroupSingleAddTest.java
@@ -57,12 +57,7 @@ public class GroupSingleAddTest extends DefaultGNSTest {
    */
   public GroupSingleAddTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: ", e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/GroupTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/GroupTest.java
@@ -59,12 +59,7 @@ public class GroupTest extends DefaultGNSTest {
    */
   public GroupTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/GuidAndGroupsRemoveTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/GuidAndGroupsRemoveTest.java
@@ -58,12 +58,7 @@ public class GuidAndGroupsRemoveTest extends DefaultGNSTest {
    */
   public GuidAndGroupsRemoveTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/GuidCreateKeyless.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/GuidCreateKeyless.java
@@ -19,16 +19,12 @@
  */
 package edu.umass.cs.gnsclient.client.singletests;
 
-import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSCommand;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
-import edu.umass.cs.gnscommon.AclAccessType;
-import edu.umass.cs.gnscommon.GNSProtocol;
 import edu.umass.cs.gnscommon.utils.RandomString;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
 
-import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commandSupport.MetaDataTypeName;
 import edu.umass.cs.gnsserver.utils.DefaultGNSTest;
 import edu.umass.cs.utils.Utils;
 import java.io.IOException;

--- a/test/edu/umass/cs/gnsclient/client/singletests/MultiFieldLookupTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/MultiFieldLookupTest.java
@@ -56,12 +56,7 @@ public class MultiFieldLookupTest extends DefaultGNSTest {
    */
   public MultiFieldLookupTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/RemoveAccountWithPasswordTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/RemoveAccountWithPasswordTest.java
@@ -50,12 +50,7 @@ public class RemoveAccountWithPasswordTest extends DefaultGNSTest {
    */
   public RemoveAccountWithPasswordTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client in RemoveAccountWithPasswordTest: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/RemoveGuidTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/RemoveGuidTest.java
@@ -48,12 +48,7 @@ public class RemoveGuidTest extends DefaultGNSTest {
    */
   public RemoveGuidTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/ResendAuthentication.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/ResendAuthentication.java
@@ -50,12 +50,7 @@ public class ResendAuthentication extends DefaultGNSTest {
    */
   public ResendAuthentication() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/SelectTest.java
@@ -19,13 +19,9 @@
  */
 package edu.umass.cs.gnsclient.client.singletests;
 
-import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSCommand;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
-import edu.umass.cs.gnsclient.client.util.JSONUtils;
-import edu.umass.cs.gnsclient.jsonassert.JSONAssert;
-import edu.umass.cs.gnsclient.jsonassert.JSONCompareMode;
 import edu.umass.cs.gnscommon.AclAccessType;
 import edu.umass.cs.gnscommon.GNSProtocol;
 import edu.umass.cs.gnscommon.exceptions.client.ClientException;
@@ -96,9 +92,9 @@ public class SelectTest extends DefaultGNSTest {
     try {
       String westyName = "westy" + RandomString.randomString(12);
       String samName = "sam" + RandomString.randomString(12);
-      client.execute(GNSCommand.createGUID(masterGuid, westyName));
+      client.execute(GNSCommand.guidCreate(masterGuid, westyName));
       westyEntry = GuidUtils.getGUIDKeys(westyName);
-      client.execute(GNSCommand.createGUID(masterGuid, samName));
+      client.execute(GNSCommand.guidCreate(masterGuid, samName));
       samEntry = GuidUtils.getGUIDKeys(samName);
 //      westyEntry = clientCommands.guidCreate(masterGuid, "westy" + RandomString.randomString(12));
 //      samEntry = clientCommands.guidCreate(masterGuid, "sam" + RandomString.randomString(12));
@@ -201,7 +197,7 @@ public class SelectTest extends DefaultGNSTest {
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
         String queryTestName = "queryTest-" + RandomString.randomString(12);
-        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        client.execute(GNSCommand.guidCreate(masterGuid, queryTestName));
         GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
 
         // Remove default all fields / all guids ACL;
@@ -238,7 +234,7 @@ public class SelectTest extends DefaultGNSTest {
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
         String queryTestName = "queryTest-" + RandomString.randomString(12);
-        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        client.execute(GNSCommand.guidCreate(masterGuid, queryTestName));
         GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
         CREATED_GUIDS.add(testEntry); // save them so we can delete them later
         JSONArray array = new JSONArray(Arrays.asList(25));
@@ -271,7 +267,7 @@ public class SelectTest extends DefaultGNSTest {
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
         String queryTestName = "queryTest-" + RandomString.randomString(12);
-        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        client.execute(GNSCommand.guidCreate(masterGuid, queryTestName));
         GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
         // Remove default all fields / all guids ACL;
         client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
@@ -306,7 +302,7 @@ public class SelectTest extends DefaultGNSTest {
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
         String queryTestName = "queryTest-" + RandomString.randomString(12);
-        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        client.execute(GNSCommand.guidCreate(masterGuid, queryTestName));
         GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
         // Remove default all fields / all guids ACL;
         client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
@@ -346,7 +342,7 @@ public class SelectTest extends DefaultGNSTest {
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
         String queryTestName = "queryTest-" + RandomString.randomString(12);
-        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        client.execute(GNSCommand.guidCreate(masterGuid, queryTestName));
         GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
         // Remove default all fields / all guids ACL;
         client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
@@ -389,7 +385,7 @@ public class SelectTest extends DefaultGNSTest {
     try {
       for (int cnt = 0; cnt < 5; cnt++) {
         String queryTestName = "queryTest-" + RandomString.randomString(12);
-        client.execute(GNSCommand.createGUID(masterGuid, queryTestName));
+        client.execute(GNSCommand.guidCreate(masterGuid, queryTestName));
         GuidEntry testEntry = GuidUtils.getGUIDKeys(queryTestName);
         // Remove default all fields / all guids ACL;
         client.execute(GNSCommand.aclRemove(AclAccessType.READ_WHITELIST, testEntry,
@@ -673,13 +669,13 @@ public class SelectTest extends DefaultGNSTest {
   public void test_999_SelectCleanup() {
     try {
       for (GuidEntry guid : CREATED_GUIDS) {
-        client.execute(GNSCommand.removeGUID(masterGuid, guid.getGuid()));
+        client.execute(GNSCommand.guidRemove(masterGuid, guid.getGuid()));
         //clientCommands.guidRemove(masterGuid, guid.getGuid());
       }
       CREATED_GUIDS.clear();
-      client.execute(GNSCommand.removeGUID(masterGuid, westyEntry.getGuid()));
+      client.execute(GNSCommand.guidRemove(masterGuid, westyEntry.getGuid()));
       //clientCommands.guidRemove(masterGuid, westyEntry.getGuid());
-      client.execute(GNSCommand.removeGUID(masterGuid, samEntry.getGuid()));
+      client.execute(GNSCommand.guidRemove(masterGuid, samEntry.getGuid()));
       //clientCommands.guidRemove(masterGuid, samEntry.getGuid());
     } catch (ClientException | IOException e) {
       Utils.failWithStackTrace("Exception during cleanup: " + e);

--- a/test/edu/umass/cs/gnsclient/client/singletests/UnsignedReadTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/UnsignedReadTest.java
@@ -56,12 +56,7 @@ public class UnsignedReadTest extends DefaultGNSTest {
    */
   public UnsignedReadTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: ", e);
-      }
+        clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/UnsignedWriteTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/UnsignedWriteTest.java
@@ -54,12 +54,7 @@ public class UnsignedWriteTest extends DefaultGNSTest {
    */
   public UnsignedWriteTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/WriteReadBytesTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/WriteReadBytesTest.java
@@ -53,13 +53,8 @@ public class WriteReadBytesTest extends DefaultGNSTest {
    */
   public WriteReadBytesTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
-        clientCommands.setForceCoordinatedReads(true).setNumRetriesUponTimeout(1);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception while trying to create the client: " + e);
-      }
-
+        clientCommands = new GNSClientCommands(client);
+        
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/failingtests/AdminBadAuthTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/failingtests/AdminBadAuthTest.java
@@ -51,7 +51,7 @@ public class AdminBadAuthTest extends DefaultGNSTest {
    * to send MUTUAL_AUTH requests to the SERVER_AUTH client port.
    *
    */
-  private static class BadClient extends GNSClientCommands {
+  private static class BadClient extends GNSClient {
 
     private BadClient(Set<InetSocketAddress> reconfigurators)
             throws IOException {
@@ -86,7 +86,7 @@ public class AdminBadAuthTest extends DefaultGNSTest {
   }
 
   private static GNSClientCommands clientCommands;
-  private static BadClient badClient;
+  private static GNSClientCommands badClient;
 
   /**
    *
@@ -96,22 +96,19 @@ public class AdminBadAuthTest extends DefaultGNSTest {
   public static void setupBeforeClass() throws IOException {
     System.out.println("Starting client");
 
-    clientCommands = new GNSClientCommands();
+    clientCommands = new GNSClientCommands(client);
 
     // Make all the reads be coordinated
     clientCommands.setForceCoordinatedReads(true);
     // arun: connectivity check embedded in GNSClient constructor
-    boolean connected = clientCommands instanceof GNSClient;
-    if (connected) {
-      System.out.println("Client created and connected to server.");
-    }
+    
+    System.out.println("Client created and connected to server.");
+    
 
-    badClient = new BadClient(ReconfigurationConfig.getReconfiguratorAddresses());
+    badClient = new GNSClientCommands
+    		(new BadClient(ReconfigurationConfig.getReconfiguratorAddresses()));
     badClient.setForceCoordinatedReads(true);
-    connected = badClient instanceof GNSClient;
-    if (connected) {
       System.out.println("BadClient created and connected to server.");
-    }
   }
 
   /**

--- a/test/edu/umass/cs/gnsclient/client/singletests/failingtests/GroupGuidLookupIndirectionTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/failingtests/GroupGuidLookupIndirectionTest.java
@@ -62,12 +62,9 @@ public class GroupGuidLookupIndirectionTest extends DefaultGNSTest {
    */
   public GroupGuidLookupIndirectionTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/failingtests/HighConcurrencyReadsTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/failingtests/HighConcurrencyReadsTest.java
@@ -19,6 +19,7 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig.TC;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSClientConfig;
 import edu.umass.cs.gnsclient.client.testing.GNSTestingConfig.GNSTC;
@@ -97,9 +98,9 @@ public class HighConcurrencyReadsTest extends DefaultGNSTest {
     executor = (ScheduledThreadPoolExecutor) Executors
             .newScheduledThreadPool(numClients);
     for (int i = 0; i < numClients; i++) {
-      clients[i] = new GNSClientCommands();
+      clients[i] = new GNSClientCommands(new GNSClient());
     }
-    String gnsInstance = GNSClientCommands.getGNSProvider();
+    String gnsInstance = clients[0].getGNSProvider();
     accountGuidEntries = new GuidEntry[numAccountGuids];
 
     int numPreExisting = 0;

--- a/test/edu/umass/cs/gnsclient/client/singletests/failingtests/SelectAutoGroupTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/failingtests/SelectAutoGroupTest.java
@@ -69,12 +69,9 @@ public class SelectAutoGroupTest extends DefaultGNSTest {
    */
   public SelectAutoGroupTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/failingtests/SubGuidDeletesTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/failingtests/SubGuidDeletesTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.notification.Failure;
 
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig;
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig.TC;
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.GNSClientConfig;
 import edu.umass.cs.gnsclient.client.testing.GNSTestingConfig.GNSTC;
@@ -78,9 +79,9 @@ public class SubGuidDeletesTest extends DefaultGNSTest {
   private void setupClientsAndGuids() throws Exception {
     clients = new GNSClientCommands[numClients];
     for (int i = 0; i < numClients; i++) {
-      clients[i] = new GNSClientCommands();
+      clients[i] = new GNSClientCommands(new GNSClient());
     }
-    String gnsInstance = GNSClientCommands.getGNSProvider();
+    String gnsInstance = clients[0].getGNSProvider();
     accountGuidEntries = new GuidEntry[numAccountGuids];
 
     for (int i = 0; i < numAccountGuids; i++) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/failingtests/WriteSizeTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/failingtests/WriteSizeTest.java
@@ -46,12 +46,9 @@ public class WriteSizeTest extends DefaultGNSTest {
    */
   public WriteSizeTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/performance/CreateMultipleGuidsTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/performance/CreateMultipleGuidsTest.java
@@ -55,12 +55,8 @@ public class CreateMultipleGuidsTest extends DefaultGNSTest {
    */
   public CreateMultipleGuidsTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/performance/PerformanceTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/performance/PerformanceTest.java
@@ -48,12 +48,9 @@ public class PerformanceTest extends DefaultGNSTest {
    */
   public PerformanceTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/performance/RemoveGuidStressTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/performance/RemoveGuidStressTest.java
@@ -19,6 +19,7 @@
  */
 package edu.umass.cs.gnsclient.client.singletests.performance;
 
+import edu.umass.cs.gnsclient.client.GNSClient;
 import edu.umass.cs.gnsclient.client.GNSClientCommands;
 import edu.umass.cs.gnsclient.client.util.GuidEntry;
 import edu.umass.cs.gnsclient.client.util.GuidUtils;
@@ -53,7 +54,7 @@ public class RemoveGuidStressTest extends DefaultGNSTest {
   public RemoveGuidStressTest() {
     if (clientCommands == null) {
       try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(new GNSClient());
         clientCommands.setForceCoordinatedReads(true);
       } catch (IOException e) {
         Utils.failWithStackTrace("Exception creating client: " + e);

--- a/test/edu/umass/cs/gnsclient/client/singletests/performance/RemoveGuidStressTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/performance/RemoveGuidStressTest.java
@@ -53,12 +53,7 @@ public class RemoveGuidStressTest extends DefaultGNSTest {
    */
   public RemoveGuidStressTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands(new GNSClient());
-        clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+        clientCommands = new GNSClientCommands(client);
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/simple/CreateAccountTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/simple/CreateAccountTest.java
@@ -56,12 +56,8 @@ public class CreateAccountTest extends DefaultGNSTest {
    */
   public CreateAccountTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
     }
   }
 

--- a/test/edu/umass/cs/gnsclient/client/singletests/simple/ReadTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/simple/ReadTest.java
@@ -54,12 +54,9 @@ public class ReadTest extends DefaultGNSTest {
    */
   public ReadTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/simple/SelectClientTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/simple/SelectClientTest.java
@@ -57,12 +57,9 @@ public class SelectClientTest extends DefaultGNSTest {
    */
   public SelectClientTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/simple/SelectGeoTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/simple/SelectGeoTest.java
@@ -59,12 +59,9 @@ public class SelectGeoTest extends DefaultGNSTest {
    */
   public SelectGeoTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/simple/SelectSingleTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/simple/SelectSingleTest.java
@@ -60,12 +60,9 @@ public class SelectSingleTest extends DefaultGNSTest {
    */
   public SelectSingleTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/simple/SingleReadArrayTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/simple/SingleReadArrayTest.java
@@ -52,12 +52,9 @@ public class SingleReadArrayTest extends DefaultGNSTest {
    */
   public SingleReadArrayTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/simple/SingleReadTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/simple/SingleReadTest.java
@@ -51,12 +51,9 @@ public class SingleReadTest extends DefaultGNSTest {
    */
   public SingleReadTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
+      
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {

--- a/test/edu/umass/cs/gnsclient/client/singletests/simple/SingleRemoveGuidTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/simple/SingleRemoveGuidTest.java
@@ -48,12 +48,8 @@ public class SingleRemoveGuidTest extends DefaultGNSTest {
    */
   public SingleRemoveGuidTest() {
     if (clientCommands == null) {
-      try {
-        clientCommands = new GNSClientCommands();
+        clientCommands = new GNSClientCommands(client);
         clientCommands.setForceCoordinatedReads(true);
-      } catch (IOException e) {
-        Utils.failWithStackTrace("Exception creating client: " + e);
-      }
       try {
         masterGuid = GuidUtils.getGUIDKeys(globalAccountName);
       } catch (Exception e) {


### PR DESCRIPTION
 Changed GNSClientCommands and tests. GNSClientCommands is now only used to execute GNSCommands by using the supplied GNSClient. All tests now use the GNSClient of the parent class, DefaultGNSTest.