### PR TITLE
Added default timeout rule to tests.

### DIFF
--- a/src/edu/umass/cs/gnsserver/utils/DefaultGNSTest.java
+++ b/src/edu/umass/cs/gnsserver/utils/DefaultGNSTest.java
@@ -37,6 +37,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 
 import edu.umass.cs.gigapaxos.PaxosConfig;
@@ -69,6 +70,9 @@ public class DefaultGNSTest extends DefaultTest {
 	private static final String HOME = System.getProperty("user.home");
 	private static final String GNS_DIR = "GNS";
 	private static final String GNS_HOME = HOME + "/" + GNS_DIR + "/";
+	
+	//aditya: added for timeout rule
+	private static final int PER_TEST_TIMEOUT	= 300; // in seconds.
 
 	protected static final String RANDOM_PASSWORD = "password"
 			+ RandomString.randomString(12);
@@ -114,6 +118,13 @@ public class DefaultGNSTest extends DefaultTest {
 			System.exit(1);
 		}
 	};
+	
+	/**
+	 * Per test timeout so that no tests blocks indefinitely. Although, GNSClient
+	 * timeout is also setup. If there is a long test then PER_TEST_TIMEOUT needs to be changed accordingly.
+	 */
+	@Rule
+	public Timeout globalTimeout = Timeout.seconds(PER_TEST_TIMEOUT);
 
 	protected static enum DefaultProps {
 		SERVER_COMMAND("server.command", GP_SERVER, true),


### PR DESCRIPTION
In this pull request, I have added a default timeout rule for JUnit tests so that the tests don't block indefinitely. The current timeout is set to 300 seconds, as I think there is no individual test that runs for 5 mins. 

This pull request can fail travis checks as it doesn't contain some bug fixes, which are fixed in the subsequent pull requests.