### PR TITLE
Some RemoveAccount and RemoveGuid fixes

### DIFF
--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/AccountAccess.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/AccountAccess.java
@@ -367,7 +367,7 @@ public class AccountAccess {
    */
   public static GuidInfo lookupGuidInfoLocally(InternalRequestHeader header, String guid,
           ClientRequestHandlerInterface handler) {
-    return lookupGuidInfo(header, guid, handler, false);
+    return lookupGuidInfo(header, guid, handler, false, true);
   }
 
   /**
@@ -384,7 +384,7 @@ public class AccountAccess {
    */
   public static GuidInfo lookupGuidInfoAnywhere(InternalRequestHeader header, String guid,
           ClientRequestHandlerInterface handler) {
-    return lookupGuidInfo(header, guid, handler, true);
+    return lookupGuidInfo(header, guid, handler, true, true);
   }
 
   /**
@@ -397,10 +397,10 @@ public class AccountAccess {
    * @param allowRemoteLookup
    * @return an {@link GuidInfo} instance
    */
-  private static GuidInfo lookupGuidInfo(InternalRequestHeader header, String guid,
-          ClientRequestHandlerInterface handler, boolean allowRemoteLookup) {
+  public static GuidInfo lookupGuidInfo(InternalRequestHeader header, String guid,
+          ClientRequestHandlerInterface handler, boolean allowRemoteLookup, boolean cacheUse) {
     GuidInfo result;
-    if ((result = GUID_INFO_CACHE.getIfPresent(guid)) != null) {
+    if ( cacheUse &&  (result = GUID_INFO_CACHE.getIfPresent(guid)) != null) {
       GNSConfig.getLogger().log(Level.FINE, "GuidInfo found in cache {0}", guid);
       return result;
     }

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/account/RemoveAccount.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/account/RemoveAccount.java
@@ -80,7 +80,9 @@ public class RemoveAccount extends AbstractCommand {
     String signature = json.getString(GNSProtocol.SIGNATURE.toString());
     String message = json.getString(GNSProtocol.SIGNATUREFULLMESSAGE.toString());
     GuidInfo guidInfo;
-    if ((guidInfo = AccountAccess.lookupGuidInfoLocally(header, guid, handler)) == null) {
+    // we don't use cache in this lookup because cache on a deletion is not updated.
+    if( (guidInfo = AccountAccess.lookupGuidInfo(header, guid, handler, true, false)) == null) {
+    //if ((guidInfo = AccountAccess.lookupGuidInfoLocally(header, guid, handler)) == null) {
       // Removing a non-existant guid is not longer an error.
       return new CommandResponse(ResponseCode.NO_ERROR, GNSProtocol.OK_RESPONSE.toString());
       //return new CommandResponse(ResponseCode.BAD_GUID_ERROR, GNSProtocol.BAD_RESPONSE.toString() + " " + GNSProtocol.BAD_GUID.toString() + " " + guid);
@@ -90,7 +92,11 @@ public class RemoveAccount extends AbstractCommand {
       if (accountInfo != null) {
         return AccountAccess.removeAccount(header, commandPacket, accountInfo, handler);
       } else {
-        return new CommandResponse(ResponseCode.BAD_ACCOUNT_ERROR, GNSProtocol.BAD_RESPONSE.toString() + " " + GNSProtocol.BAD_ACCOUNT.toString());
+    	  // aditya: Changing from ResponseCode.BAD_ACCOUNT_ERROR to NO_ERROR. As, In RemoveAccount, we want to
+    	  // remove the account, but there is no accountInfo anywhere in the GNS, so it has already been
+    	  // deleted by a previous or concurrent remove.
+        return new CommandResponse(ResponseCode.NO_ERROR, GNSProtocol.OK_RESPONSE.toString() 
+        		+ " Couldn't find the account information for "+name+" because account is already removed." );
       }
     } else {
       return new CommandResponse(ResponseCode.SIGNATURE_ERROR, GNSProtocol.BAD_RESPONSE.toString() + " " + GNSProtocol.BAD_SIGNATURE.toString());

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/account/RemoveGuid.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commands/account/RemoveGuid.java
@@ -79,10 +79,13 @@ public class RemoveGuid extends AbstractCommand {
     String message = json.getString(GNSProtocol.SIGNATUREFULLMESSAGE.toString());
     GuidInfo accountGuidInfo = null;
     GuidInfo guidInfoToRemove;
-    if ((guidInfoToRemove = AccountAccess.lookupGuidInfoLocally(header, guidToRemove, handler)) == null) {
+    
+    // We don't use cache in this lookup because cache on a deletion is not updated. A GUID
+    // might be deleted in the database but still be present in the cache. 
+    if ((guidInfoToRemove = AccountAccess.lookupGuidInfo(header, guidToRemove, handler, true, false)) == null) 
+    {
       // Removing a non-existant guid is no longer an error.
       return new CommandResponse(ResponseCode.NO_ERROR, GNSProtocol.OK_RESPONSE.toString());
-      //return new CommandResponse(ResponseCode.BAD_GUID_ERROR, GNSProtocol.BAD_RESPONSE.toString() + " " + GNSProtocol.BAD_GUID.toString() + " " + guidToRemove);
     }
     if (accountGuid != null) {
       if ((accountGuidInfo = AccountAccess.lookupGuidInfoAnywhere(header, accountGuid, handler)) == null) {

--- a/src/edu/umass/cs/gnsserver/utils/DefaultGNSTest.java
+++ b/src/edu/umass/cs/gnsserver/utils/DefaultGNSTest.java
@@ -37,6 +37,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 
 import edu.umass.cs.gigapaxos.PaxosConfig;
@@ -69,6 +70,9 @@ public class DefaultGNSTest extends DefaultTest {
 	private static final String HOME = System.getProperty("user.home");
 	private static final String GNS_DIR = "GNS";
 	private static final String GNS_HOME = HOME + "/" + GNS_DIR + "/";
+	
+	//aditya: added for timeout rule
+	private static final int PER_TEST_TIMEOUT	= 300; // in seconds.
 
 	protected static final String RANDOM_PASSWORD = "password"
 			+ RandomString.randomString(12);
@@ -114,6 +118,13 @@ public class DefaultGNSTest extends DefaultTest {
 			System.exit(1);
 		}
 	};
+	
+	/**
+	 * Per test timeout so that no tests blocks indefinitely. Although, GNSClient
+	 * timeout is also setup. If there is a long test then PER_TEST_TIMEOUT needs to be changed accordingly.
+	 */
+	@Rule
+	public Timeout globalTimeout = Timeout.seconds(PER_TEST_TIMEOUT);
 
 	protected static enum DefaultProps {
 		SERVER_COMMAND("server.command", GP_SERVER, true),

--- a/test/edu/umass/cs/gnsclient/client/singletests/BatchCreateTest.java
+++ b/test/edu/umass/cs/gnsclient/client/singletests/BatchCreateTest.java
@@ -50,7 +50,15 @@ import org.junit.runners.MethodSorters;
 public class BatchCreateTest extends DefaultGNSTest {
 
   private static GNSClientCommands clientCommands;
+  
+  /**
+   * These constants are copied from  {@link edu.umass.cs.gnsserver.gnsapp.GNSClientInternal}
+   */
+  private static final long RC_TIMEOUT = 6000;
+  // plus 1 second for every 20 names in batch creates
+  private static final double BATCH_TIMEOUT_FACTOR = 1000 / 20;
 
+  
   /**
    *
    */
@@ -61,7 +69,7 @@ public class BatchCreateTest extends DefaultGNSTest {
   }
 
   private static int numberToCreate = 2;
-
+  
   /**
    * The test set for testing batch creates. The test will create batches
    * of size 2, 4, 8,..., 128.
@@ -76,7 +84,8 @@ public class BatchCreateTest extends DefaultGNSTest {
     test_511_CreateBatch(accountGuidForBatch);
     test_512_CheckBatch(accountGuidForBatch);
     numberToCreate *= 2;
-    client.execute(GNSCommand.accountGuidRemove(accountGuidForBatch));
+    client.execute(GNSCommand.accountGuidRemove(accountGuidForBatch), 
+    		Math.max(getTimeout() , TIMEOUT));
   }
 
   /**
@@ -137,6 +146,14 @@ public class BatchCreateTest extends DefaultGNSTest {
     } catch (JSONException | ClientException | IOException e) {
       Utils.failWithStackTrace("Exception while fetching account record: ", e);
     }
+  }
+  
+  
+  private static long getTimeout() 
+  {
+	  long timeout = RC_TIMEOUT;
+	  timeout += numberToCreate * BATCH_TIMEOUT_FACTOR;
+	  return timeout;
   }
 
 }


### PR DESCRIPTION
This pull request contains the following changes.

1) I have added a timeout for the batch removal of GUIDs. The file changed is BatchCreateTest.java. The timeout logic is similar to the one used in the GNSClientInternal.java. I have also checked that the removal works in case there is a timeout and the remove account request is reissued. 

2) I have fixed a false BAD_ACCOUNT_ERROR in RemoveAccount.java. In this case, the GNS was not finding the account information for the account it wanted to remove and it was throwing a BAD_ACCOUNT_ERROR. But, the account was already removed because of concurrent or previous command, so the GNS should return a NO_ERROR. 
3) I made some changes to the GUID lookup calls used in the GNS. Some calls were assuming the GUID to be always stored locally, which may not be true. At some places, the code was reading information for the GUID info cache that is inconsistent as it is not updated on a GUID removal. 
4) I also made changes so that the GNS returns a TIMEOUT error in case of a TIMEOUT. At some places, the GNS was returning an UPDATE_ERROR in case of a TIMEOUT, which was preventing the GNSClient from retrying. 

I am issuing all the above changes in just one pull request, instead of two, because two pull requests might end up in having some conflicting code.

This is the pull request that contains all changes and the "ant test" error rate for this pull request is <0.1%, so all travis checks should pass. 