### PR TITLE
Added support for non-blocking selects in the GNS.

### DIFF
--- a/src/edu/umass/cs/gnscommon/packets/CommandPacket.java
+++ b/src/edu/umass/cs/gnscommon/packets/CommandPacket.java
@@ -98,8 +98,13 @@ public class CommandPacket extends BasicPacketWithClientAddress implements
    */
   public CommandPacket(long requestId, JSONObject command) {
     this(requestId, command, true);
+    // We don't need to set the sender address in this constructor 
+    // because this constructor is only used to construct a command.
+    // This constructor is not used to get a CommandPacket object 
+    // after receiving a command from NIO. 
   }
-
+  
+  
   /**
    * Create a CommandPacket instance.
    *
@@ -114,6 +119,10 @@ public class CommandPacket extends BasicPacketWithClientAddress implements
     if (validate) {
       validateCommandType();
     }
+    // We don't need to set the sender address in this constructor 
+    // because this constructor is only used to construct a command.
+    // This constructor is not used to get a CommandPacket object 
+    // after receiving a command from NIO. 
   }
 
   /**
@@ -123,6 +132,8 @@ public class CommandPacket extends BasicPacketWithClientAddress implements
    * @throws JSONException
    */
   public CommandPacket(JSONObject json) throws JSONException {
+	  // for setting the  client address in BasicPacketWithClientAddress
+	  super(json);
     this.type = Packet.getPacketType(json);
 
     if (!SUPPORT_OLD_PROTOCOL) {
@@ -160,7 +171,7 @@ public class CommandPacket extends BasicPacketWithClientAddress implements
    */
   public CommandPacket(byte[] bytes) throws RequestParseException {
     ByteBuffer buf = ByteBuffer.wrap(bytes);
-
+    
     /**
      * We will come here only if this class implements Byteable and the
      * sender also implements Byteable. If the sender used toJSONObject(),
@@ -179,8 +190,12 @@ public class CommandPacket extends BasicPacketWithClientAddress implements
             (int) buf.get());
     // JSON command
     this.command = getJSONObject(buf, mode);
-
+    
     validateCommandType();
+    
+    throw new RequestParseException(new RuntimeException(
+    		"This constructor doesn't set the client address, which is needed for non-blocking selects. So, this "
+    		+ "constructor should not be used."));
   }
 
   /**

--- a/src/edu/umass/cs/gnscommon/packets/PacketUtils.java
+++ b/src/edu/umass/cs/gnscommon/packets/PacketUtils.java
@@ -167,6 +167,29 @@ public class PacketUtils {
 						}
 						return GNSConfig.getInternalOpSecret().equals(proof);
 					}
+					
+					/**
+					 * Returns the client IP address of the client that
+					 * sent this command. This is used to process
+					 * commands in a non-blocking manner, like in a non-blocking 
+					 * custom select implementation.
+					 */
+					public String getSourceAddress() 
+					{
+						return commandPacket.getClientAddress().getAddress().getHostAddress();
+					}
+					
+					/**
+					 * Returns the client port that
+					 * sent this command. This is used to process
+					 * commands in a non-blocking manner, like in a non-blocking 
+					 * custom select implementation. 
+					 */
+					public int getSourcePort()
+					{
+						return commandPacket.getClientAddress().getPort();
+					}
+					
 				};
 	}
 

--- a/src/edu/umass/cs/gnsserver/gnsapp/GNSApp.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/GNSApp.java
@@ -722,6 +722,11 @@ public class GNSApp extends AbstractReconfigurablePaxosApp<String> implements
   public BasicRecordMap getDB() {
     return nameRecordDB;
   }
+  
+  @Override
+  public SSLMessenger<String, JSONObject> getSSLMessenger() {
+	  return this.messenger;
+  }
 
   /**
    *

--- a/src/edu/umass/cs/gnsserver/gnsapp/GNSApplicationInterface.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/GNSApplicationInterface.java
@@ -30,6 +30,7 @@ import edu.umass.cs.gnscommon.packets.CommandPacket;
 import edu.umass.cs.gnsserver.activecode.ActiveCodeHandler;
 import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.ClientRequestHandlerInterface;
 import edu.umass.cs.gnsserver.gnsapp.recordmap.BasicRecordMap;
+import edu.umass.cs.nio.interfaces.SSLMessenger;
 
 /**
  * This encapsulates the core functionality needed by the GNS Application.
@@ -103,5 +104,11 @@ public interface GNSApplicationInterface<NodeIDType> {
    * @return the active code handler
    */
   ActiveCodeHandler getActiveCodeHandler();
-
+  
+  /**
+   * Returns the SSLMessenger. 
+   * @return returns the SSLMessenger.
+   */
+  public SSLMessenger<NodeIDType, JSONObject> getSSLMessenger();
+  
 }

--- a/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/FieldAccess.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientCommandProcessor/commandSupport/FieldAccess.java
@@ -41,6 +41,7 @@ import org.json.JSONObject;
 import edu.umass.cs.gnscommon.GNSProtocol;
 import edu.umass.cs.gnscommon.ResponseCode;
 import edu.umass.cs.gnscommon.SharedGuidUtils;
+import edu.umass.cs.gnscommon.exceptions.client.ClientException;
 import edu.umass.cs.gnscommon.exceptions.server.FailedDBOperationException;
 import edu.umass.cs.gnscommon.exceptions.server.FieldNotFoundException;
 import edu.umass.cs.gnscommon.exceptions.server.InternalRequestException;
@@ -759,9 +760,10 @@ public class FieldAccess {
         return new CommandResponse(ResponseCode.NO_ERROR, result.toString());
       }
     } catch (IOException | JSONException | FailedDBOperationException e) {
-      // FIXME: why silently fail?
+    	ClientException cle = new ClientException(e);
+    	return new CommandResponse(cle.getCode(), "selectQuery failed. "+cle.getMessage());
     }
-    return new CommandResponse(ResponseCode.NO_ERROR, EMPTY_JSON_ARRAY_STRING);
+    return null;
   }
 
   /**
@@ -830,11 +832,10 @@ public class FieldAccess {
         return new CommandResponse(ResponseCode.NO_ERROR, result.toString());
       }
     } catch (IOException | JSONException | FailedDBOperationException e) {
-      LOGGER.log(Level.FINE,
-              "Silently failing select for query: {0} field: {1} reader: {2} due to {3}",
-              new Object[]{guid, query, reader, e.getMessage()});
+    	ClientException cle = new ClientException(e);
+    	return new CommandResponse(cle.getCode(), "selectGroupSetupQuery failed. "+cle.getMessage());
     }
-    return new CommandResponse(ResponseCode.NO_ERROR, EMPTY_JSON_ARRAY_STRING);
+    return null;
   }
 
   /**
@@ -862,9 +863,10 @@ public class FieldAccess {
         return new CommandResponse(ResponseCode.NO_ERROR, result.toString());
       }
     } catch (IOException | JSONException | FailedDBOperationException e) {
-      // FIXME: why silently fail?
+    	ClientException cle = new ClientException(e);
+    	return new CommandResponse(cle.getCode(), "selectGroupLookupQuery failed. "+cle.getMessage());
     }
-    return new CommandResponse(ResponseCode.NO_ERROR, EMPTY_JSON_ARRAY_STRING);
+    return null;
   }
 
   /**

--- a/src/edu/umass/cs/gnsserver/interfaces/InternalRequestHeader.java
+++ b/src/edu/umass/cs/gnsserver/interfaces/InternalRequestHeader.java
@@ -84,4 +84,18 @@ public interface InternalRequestHeader {
 	default String getSourceAddress() {
 		return null;
 	}
+	
+	/**
+	 * Returns the source port.
+	 * {@link #getSourceAddress()} and {@link #getSourcePort()} 
+	 * methods are separate to maintain the backward compatibility, i.e.,
+	 * at many places in the GNS
+	 * only {@link #getSourceAddress()} is used.
+	 * 
+	 * @return Returns the source port.
+	 */
+	default int getSourcePort()
+	{
+		return -1;
+	}
 }


### PR DESCRIPTION
In this pull request, I have added the support for non-blocking selects in the GNS.
The summary of changes is as follows:
1) In the CommandPacket, I have added the support to read a client's address from a JSON representation of a command. The byte array constructor is not supported and throws a run time exception. 
2) In the InternalRequestHeader, I have added the support to store and retrieve client socket address.
3) The places where a command returns null, I have disabled the checking of assertions. 