### PR TITLE
Added a flag that by default disables the logging of updates as INFO logs

### DIFF
--- a/src/edu/umass/cs/gnsserver/gnsapp/clientSupport/NSUpdateSupport.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/clientSupport/NSUpdateSupport.java
@@ -180,8 +180,10 @@ public class NSUpdateSupport {
     }
     // Apply updateEntireValuesMap to record in the database
     nameRecord.updateNameRecord(field, updateValue, oldValue, argument, newValue, operation);
+    
     // This is for MOB-893 - logging updates
-    writeUpdateLog(guid, field, updateValue, newValue, operation);
+    if(Config.getGlobalBoolean(GNSConfig.GNSC.ENABLE_UPDATE_LOGGING))
+    	writeUpdateLog(guid, field, updateValue, newValue, operation);
   }
 
   // This is for MOB-893 - logging updates

--- a/src/edu/umass/cs/gnsserver/main/GNSConfig.java
+++ b/src/edu/umass/cs/gnsserver/main/GNSConfig.java
@@ -274,6 +274,14 @@ public class GNSConfig {
      * Class name of select implementation.
      */
     ABSTRACT_SELECTOR(edu.umass.cs.gnsserver.gnsapp.Select.class.getCanonicalName()),
+    
+    /**
+     * If the flag is true then the update 
+     * requests are logged in the GNS logs as INFO log
+     * statements. For experiments measuring the update capacity
+     * this flag should be false. 
+     */
+    ENABLE_UPDATE_LOGGING(false),
     ;
 
     final Object defaultValue;


### PR DESCRIPTION
In this pull request, I have added a flag that by default disables the logging of GNS updates as INFO logs. 