### PR TITLE
Added changes to select and ACL checks

### DIFF
--- a/src/edu/umass/cs/gnsserver/main/GNSConfig.java
+++ b/src/edu/umass/cs/gnsserver/main/GNSConfig.java
@@ -34,7 +34,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.umass.cs.gnsclient.client.GNSClientConfig;
-import edu.umass.cs.gnsclient.console.commands.Select;
 import edu.umass.cs.gnsserver.extensions.sanitycheck.NullSanityCheck;
 import edu.umass.cs.gnsserver.gnsapp.AbstractSelector;
 import edu.umass.cs.reconfiguration.reconfigurationutils.ReconfigurationRecord;


### PR DESCRIPTION
In this pull request, I have added the following changes.

1) The ACL checks in select requests doesn't read a name record more than once.
2) A select response from a name server to an entry name server doesn't send the public keys corresponding to GUIDs in the select response. 
3) Minor mongodb index fixing, so that the integer indexes, +1, -1 in mongodb, can also be given as input. 