### PR TITLE
Fixed the aribtrary names for select request packets bug.

### DIFF
--- a/src/edu/umass/cs/gnsserver/gnsapp/packet/SelectRequestPacket.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/packet/SelectRequestPacket.java
@@ -25,8 +25,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
-import edu.umass.cs.gnscommon.utils.Base64;
-import edu.umass.cs.gnsserver.gnsapp.clientCommandProcessor.commandSupport.ShaOneHashFunction;
 import edu.umass.cs.gnsserver.utils.JSONUtils;
 
 /**

--- a/src/edu/umass/cs/gnsserver/gnsapp/packet/SelectRequestPacket.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/packet/SelectRequestPacket.java
@@ -406,13 +406,13 @@ public class SelectRequestPacket extends BasicPacketWithNSReturnAddress
    */
   @Override
   public String getServiceName() {
-    if (query != null) {
-      // FIXME: maybe cache this
-      return Base64.encodeToString(ShaOneHashFunction.getInstance().hash(this.query), false);
-    } else {
-      // FIXME:
-      return "_SelectRequest_";
-    }
+	  // aditya: all select request packets should have this name.
+	  // All select requests should have same name because edu.umass.cs.reconfiguration.ActiveReplica
+	  // stores a demand profile for each distinct name, so we tag all select requests with 
+	  // the same  name so that they have only one name and edu.umass.cs.reconfiguration.ActiveReplica
+	  // stores only one demand profile. 
+	  
+	  return "SelectRequest";
   }
 
   /**

--- a/src/edu/umass/cs/gnsserver/gnsapp/packet/SelectResponsePacket.java
+++ b/src/edu/umass/cs/gnsserver/gnsapp/packet/SelectResponsePacket.java
@@ -249,8 +249,14 @@ public class SelectResponsePacket extends BasicPacketWithReturnAddressAndNsAddre
    */
   @Override
   public String getServiceName() {
-    // FIXME:
-    return "SelectResponse";
+	  
+	  // aditya: all select response packets should have this name. 
+	  // All select responses should have same name because edu.umass.cs.reconfiguration.ActiveReplica
+	  // stores a demand profile for each distinct name, so we tag all select responses with 
+	  // the same  name so that they have only one name and edu.umass.cs.reconfiguration.ActiveReplica
+	  // stores only one demand profile. 
+	  
+	  return "SelectResponse";
   }
 
   /**


### PR DESCRIPTION
In this pull requests, I have fixed the following. In the earlier implementation, the name of a SelectRequestPacket was the hash of its select query. So, for different select queries their corresponding SelectRequestPackets had different names. ActiveReplica.java stores demand profiles corresponding to each distinct name. In an experiment, I found that a lot of demand profiles were stored in an active replica, which was also causing trimming and unnecessary reporting of demand profiles to reconfigurators. So, I have fixed the names for the SelectRequestPacket and SelectResponsePacket to "SelectRequest" and "SelectResponse" respectively. 
