### PR TITLE
Assign a fake class to CommandClass to avoid NPE in iOS

### DIFF
--- a/src/edu/umass/cs/gnscommon/CommandType.java
+++ b/src/edu/umass/cs/gnscommon/CommandType.java
@@ -1636,6 +1636,8 @@ public enum CommandType {
         try {
             commandClazz = Class.forName(commandClass);
         } catch (ClassNotFoundException e) {
+            // Assign a fake class for iOS client to work
+            commandClazz = String.class;
             GNSConfig.getLogger().log(Level.WARNING,
                     "Command class not found: {0}", commandClass);
         }


### PR DESCRIPTION
This fix was already present but a recent merge somehow removed it. I'm pulling this change again.